### PR TITLE
exporting keyring in asc format for apt/trusted.gpg.d directory

### DIFF
--- a/builder/bootstrap
+++ b/builder/bootstrap
@@ -13,7 +13,7 @@ mount -t tmpfs -o size=2G tmpfs "$chroot_dir"
 chmod 755 "$chroot_dir"
 container=lxc debootstrap --keyring "$keyring" --arch "$arch" --variant minbase "$version" "$chroot_dir" "$repo" bookworm || (cat "$chroot_dir/debootstrap/debootstrap.log"; false)
 
-cp "$keyring" "$chroot_dir/etc/apt/trusted.gpg.d/keyring.gpg"
+gpg --keyring "$keyring" --no-default-keyring --export -a > "$chroot_dir/etc/apt/trusted.gpg.d/keyring.asc"
 echo "deb $repo $version main" > "$chroot_dir/etc/apt/sources.list"
 
 find "$chroot_dir/proc" "$chroot_dir/sys" "$chroot_dir/dev" "$chroot_dir/run" "$chroot_dir/tmp" -mindepth 1 -delete

--- a/pkg.list
+++ b/pkg.list
@@ -9,6 +9,7 @@ datefudge
 debootstrap
 e2fsprogs
 fdisk
+gnupg2
 libcurl4
 libengine-pkcs11-openssl
 libjson-c5


### PR DESCRIPTION
During `apt update` I got the error

    W: http://repo.gardenlinux.io/gardenlinux/dists/today/InRelease: The key(s) in the keyring /etc/apt/trusted.gpg.d/keyring.gpg are ignored as the file has an unsupported filetype.

The reason was, that the `keyring.gpg` was copied to `/etc/apt/trusted.gpg.d/` in a wrong format.

Please also check the current gardenlinux builds for this error.