### PR TITLE
Add xorriso to pkg.list

### DIFF
--- a/pkg.list
+++ b/pkg.list
@@ -26,4 +26,5 @@ sbsigntool
 squashfs-tools
 systemd
 uidmap
+xorriso
 xz-utils


### PR DESCRIPTION
**What this PR does / why we need it**:
We need this in the builder to be able to build GL iso images.