### PR TITLE
fix unbound variables and add cname_base cmd

### DIFF
--- a/builder/parse_features
+++ b/builder/parse_features
@@ -23,6 +23,7 @@ def main():
 
 	args_type_allowed = [
 		"cname",
+		"cname_base",
 		"features",
 		"platforms",
 		"flags",
@@ -46,8 +47,11 @@ def main():
 	else:
 		input_features = args.features
 
+	arch = None
 	if args.arch:
 		arch = args.arch
+
+	version = None
 	if args.version:
 		version = args.version
 
@@ -90,7 +94,9 @@ def main():
 	cname_base = get_cname_base(sorted_minimal_features)
 	cname = f"{cname_base}-{arch}-{version}"
 
-	if args.type == "cname":
+	if args.type == "cname_base":
+		print(cname_base)
+	elif args.type == "cname":
 		print(cname)
 	elif args.type == "features":
 		print(",".join(features))


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes unbound variable errors when omitting the `arch` or `version` cmd-line parameter and adds a `cname_base` command that only prints out the cname without version and arch.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Fixes unbound variable errors when omitting the `arch` or `version` cmd-line parameter and adds a `cname_base` command that only prints out the cname without version and arch.
```
