### PR TITLE
Configure docker metadata for dependabot

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: nkraetzschmar/workflow-telemetry-action@v1
+      - uses: gardenlinux/workflow-telemetry-action@v1
         with:
           metric_frequency: 1
           comment_on_pr: false

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,10 @@ RUN cd aws-kms-pkcs11 && make -j "$(nproc)" AWS_SDK_STATIC=y install
 RUN cp "/usr/lib/$(uname -m)-linux-gnu/pkcs11/aws_kms_pkcs11.so" /aws_kms_pkcs11.so
 
 FROM debian:testing
+
+LABEL org.opencontainers.image.source="https://github.com/gardenlinux/builder"
+LABEL org.opencontainers.image.description="Builder for Garden Linux"
+
 COPY pkg.list /pkg.list
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends $(cat /pkg.list) && rm /pkg.list
 COPY --from=mv_data /usr/bin/mv_data /usr/bin/mv_data


### PR DESCRIPTION
Dependabot expects the link to the source repo as described here: 
https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#docker
