### PR TITLE
Build from 'builder.dockerfile' if exists

### DIFF
--- a/build
+++ b/build
@@ -75,7 +75,8 @@ done
 
 if [ "$container_image" = localhost/builder ]; then
 	dir="$(dirname -- "$(realpath -- "${BASH_SOURCE[0]}")")"
-	"$container_engine" build -t "$container_image" "$dir"
+	containerfile=$([[ -f builder.dockerfile ]] && echo -f builder.dockerfile || true )
+	"$container_engine" build -t "$container_image" $containerfile "$dir"
 fi
 
 repo="$(./get_repo)"


### PR DESCRIPTION
This change allows to track the used Builder tag in a Dockerfile. This is useful for using Dependabot to keep the builder version up to date.

Users of the Builder who wish to use Dependabot will need to create a `builder.dockerfile` next to their `build` script with the following contents:

```
FROM ghcr.io/gardenlinux/builder:SHA
```

Where SHA will be updated by dependabot if configured correctly.

also users will need to set the `container_image` value in `build` to `localhost/builder`