### PR TITLE
Build from 'builder.dockerfile' if that exists

### DIFF
--- a/build
+++ b/build
@@ -75,8 +75,14 @@ done
 
 if [ "$container_image" = localhost/builder ]; then
 	dir="$(dirname -- "$(realpath -- "${BASH_SOURCE[0]}")")"
-	containerfile=$([[ -f builder.dockerfile ]] && echo -f builder.dockerfile || true )
-	"$container_engine" build -t "$container_image" $containerfile "$dir"
+	# Build from 'builder.dockerfile' if that exists, otherwise the default file name will be 'Dockerfile' or 'Containerfile'.
+	# It is recommended to call the file 'builder.dockerfile' to make it's intention clear.
+	# That file might only contain a single line 'FROM ghcr.io/gardenlinux/builder:...' which can be updated via dependabot.
+	if [[ -f builder.dockerfile ]]; then
+		"$container_engine" build -t "$container_image" -f builder.dockerfile "$dir"
+	else 
+		"$container_engine" build -t "$container_image" "$dir"
+	fi
 fi
 
 repo="$(./get_repo)"


### PR DESCRIPTION
This change is needed to allow keeping the builder updated via dependabot.
