### PR TITLE
Release Workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,7 +59,7 @@ jobs:
           .github/workflows/release.sh ${{ secrets.GITHUB_TOKEN }} ${{ github.repository }} upload "$release" download/build
 
   # Run for new intentional versions, bumping the major or minor version
-  release-semver:
+  release-new-version:
     runs-on: ubuntu-latest
     needs: build
     if: github.ref == 'refs/heads/main' && github.event.inputs.component != ''
@@ -80,7 +80,7 @@ jobs:
         run: |
           git tag ${{ steps.bump.outputs.newVersion }}
           git push origin ${{ steps.bump.outputs.newVersion }}
-      - name: create release (semantic)
+      - name: create release (new version)
         run: |
           release="$(.github/workflows/release.sh ${{ secrets.GITHUB_TOKEN }} ${{ github.repository }} create ${{ steps.bump.outputs.newVersion }} "Builder (${{ steps.bump.outputs.newVersion }})")"
           .github/workflows/release.sh ${{ secrets.GITHUB_TOKEN }} ${{ github.repository }} upload "$release" download/build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,11 @@
-on: push
+on:
+  push:
+  workflow_dispatch:
+    inputs:
+      component:
+        description: 'Version component to increment (major or minor)'
+        required: false
+        default: 'minor'
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -33,6 +40,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: tag latest
+        if: github.event.inputs.component == ''
         run: |
           git tag --force latest
           git push --force origin latest
@@ -40,7 +48,27 @@ jobs:
         with:
           name: build
           path: download
-      - name: create release
+      - run: echo Version Component to Increase is ${{ github.event.inputs.component }}
+      - name: create release (latest)
+        if: github.event.inputs.component == ''
         run: |
           release="$(.github/workflows/release.sh ${{ secrets.GITHUB_TOKEN }} ${{ github.repository }} create latest Builder)"
+          .github/workflows/release.sh ${{ secrets.GITHUB_TOKEN }} ${{ github.repository }} upload "$release" download/build
+      - name: Get Version Number
+        if: github.event.inputs.component != ''
+        uses: gardenlinux/bump-version@main
+        id: bump
+        with:
+          component: ${{ github.event.inputs.component }}
+      - run: echo New version number ${{ steps.bump.outputs.newVersion }}
+        if: github.event.inputs.component != ''
+      - name: tag version
+        if: github.event.inputs.component != ''
+        run: |
+          git tag ${{ steps.bump.outputs.newVersion }}
+          git push origin ${{ steps.bump.outputs.newVersion }}
+      - name: create release (semantic)
+        if: github.event.inputs.component != ''
+        run: |
+          release="$(.github/workflows/release.sh ${{ secrets.GITHUB_TOKEN }} ${{ github.repository }} create ${{ steps.bump.outputs.newVersion }} Builder)"
           .github/workflows/release.sh ${{ secrets.GITHUB_TOKEN }} ${{ github.repository }} upload "$release" download/build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,11 +1,15 @@
+name: Build and Release
 on:
   push:
   workflow_dispatch:
     inputs:
       component:
-        description: 'Version component to increment (major or minor)'
+        description: 'Version component to increment (Use *minor* unless we have breaking changes)'
         required: false
-        default: 'minor'
+        type: choice
+        options:
+          - minor
+          - major
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -33,14 +37,15 @@ jobs:
         with:
           name: build
           path: build
-  release:
+
+  # Run for new commits on the main branch
+  release-latest:
     runs-on: ubuntu-latest
     needs: build
-    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main' && github.event.inputs.component == ''
     steps:
       - uses: actions/checkout@v3
       - name: tag latest
-        if: github.event.inputs.component == ''
         run: |
           git tag --force latest
           git push --force origin latest
@@ -48,27 +53,35 @@ jobs:
         with:
           name: build
           path: download
-      - run: echo Version Component to Increase is ${{ github.event.inputs.component }}
-      - name: create release (latest)
-        if: github.event.inputs.component == ''
+      - name: create release
         run: |
-          release="$(.github/workflows/release.sh ${{ secrets.GITHUB_TOKEN }} ${{ github.repository }} create latest Builder)"
+          release="$(.github/workflows/release.sh ${{ secrets.GITHUB_TOKEN }} ${{ github.repository }} create latest "Builder (latest)")"
           .github/workflows/release.sh ${{ secrets.GITHUB_TOKEN }} ${{ github.repository }} upload "$release" download/build
-      - name: Get Version Number
-        if: github.event.inputs.component != ''
-        uses: gardenlinux/bump-version@main
-        id: bump
+
+  # Run for new intentional versions, bumping the major or minor version
+  release-semver:
+    runs-on: ubuntu-latest
+    permissions: write-all
+    needs: build
+    if: github.ref == 'refs/heads/main' && github.event.inputs.component != ''
+    steps:
+      - uses: actions/checkout@v3
         with:
-          component: ${{ github.event.inputs.component }}
+          fetch-depth: 0
+      - uses: actions/download-artifact@v3
+        with:
+          name: build
+          path: download
+      - run: echo Version Component to Increase is ${{ github.event.inputs.component }}
+      - name: Get Version Number
+        run: .github/workflows/bump.py ${{ github.event.inputs.component }}
+        id: bump
       - run: echo New version number ${{ steps.bump.outputs.newVersion }}
-        if: github.event.inputs.component != ''
       - name: tag version
-        if: github.event.inputs.component != ''
         run: |
           git tag ${{ steps.bump.outputs.newVersion }}
           git push origin ${{ steps.bump.outputs.newVersion }}
       - name: create release (semantic)
-        if: github.event.inputs.component != ''
         run: |
-          release="$(.github/workflows/release.sh ${{ secrets.GITHUB_TOKEN }} ${{ github.repository }} create ${{ steps.bump.outputs.newVersion }} Builder)"
+          release="$(.github/workflows/release.sh ${{ secrets.GITHUB_TOKEN }} ${{ github.repository }} create ${{ steps.bump.outputs.newVersion }} "Builder (${{ steps.bump.outputs.newVersion }})")"
           .github/workflows/release.sh ${{ secrets.GITHUB_TOKEN }} ${{ github.repository }} upload "$release" download/build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,7 +61,6 @@ jobs:
   # Run for new intentional versions, bumping the major or minor version
   release-semver:
     runs-on: ubuntu-latest
-    permissions: write-all
     needs: build
     if: github.ref == 'refs/heads/main' && github.event.inputs.component != ''
     steps:

--- a/.github/workflows/bump.py
+++ b/.github/workflows/bump.py
@@ -1,0 +1,96 @@
+#!/usr/bin/python
+
+"""
+Determine next version number for versions of a schema like v1.0
+based on existing git tags and which component to bump (minor/major).
+"""
+
+import subprocess
+import re
+import sys
+import os
+
+
+def convert_version_to_sortable_int(major, minor):
+    return major * 1000 + minor
+
+
+def determine_most_recent_existing_version():
+    tags = subprocess.run(["git", "tag"], capture_output=True).stdout.splitlines()
+
+    versions = []
+
+    for t in tags:
+        tag = t.decode()
+        if re.match(r"v[0-9]+.[0-9]+", tag):
+            tag_without_prefix = tag[1:]
+            components = tag_without_prefix.split(".")
+            assert len(components) == 2
+            major_int = int(components[0])
+            minor_int = int(components[1])
+            versions.append(
+                {
+                    "tag": tag,
+                    "sortNumber": convert_version_to_sortable_int(major_int, minor_int),
+                    "major": major_int,
+                    "minor": minor_int,
+                }
+            )
+
+    if len(versions) == 0:
+        print("No existing versions found")
+        return {
+            "tag": "v0.0",
+            "sortNumber": convert_version_to_sortable_int(0, 0),
+            "major": 0,
+            "minor": 0,
+        }
+
+    def keyToSortVersions(v):
+        return v["sortNumber"]
+
+    versions.sort(key=keyToSortVersions, reverse=True)
+    print(f"Sorted list of versions: {versions}")
+    highest_existing_version_number = versions[0]
+
+    return highest_existing_version_number
+
+
+def bump(most_recent_version, component_to_bump):
+    new_version = ""
+
+    if component_to_bump == "major":
+        new_major = most_recent_version["major"] + 1
+        new_version = f"v{new_major}.0"
+    elif component_to_bump == "minor":
+        new_minor = most_recent_version["minor"] + 1
+        major = most_recent_version["major"]
+        new_version = f"v{major}.{new_minor}"
+    else:
+        raise (
+            f"Invalid component provided: {component_to_bump}, only major or minor are supported."
+        )
+
+    return new_version
+
+
+def determine_component_to_bump():
+    if sys.argv[1] not in ["major", "minor"]:
+        raise ("Usage: bump.py (major|minor)")
+    return sys.argv[1]
+
+
+def main():
+    component_to_bump = determine_component_to_bump()
+    most_recent_version = determine_most_recent_existing_version()
+    new_version = bump(most_recent_version, component_to_bump)
+
+    if os.getenv("GITHUB_OUTPUT"):
+        with open(os.environ["GITHUB_OUTPUT"], "a") as file_handle:
+            print(f"newVersion={new_version}", file=file_handle)
+    else:
+        print(f"No GitHub env found. New version is {new_version}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This PR implements a release workflow for a introducing semantic versions to the builder.
Minor version updates are expected to be compatible between the `build` script and the OCI image.
Major version upgrades may introduce breaking changes between the `build` script and the OCI image.

This change will improve how the builder can be kept up to date with dependabot.