### PR TITLE
Split build and release workflow

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,17 @@
+# Garden Linux Builder CI Workflows
+
+## `build.yml`
+
+Build container images on all branches.
+
+For pushes on the `main` branch, tags based on the git sha are created and pushed to the container registry and a pseudo-release called `latest` is updated on GitHub.
+This allows users to follow a rolling-release approach if they desire.
+
+## `release.yml`
+
+Tag container images and create GitHub Releases.
+This workflow only runs on demand (workflow dispatch).
+It should be run if a new release is desired.
+The workflow dispatch needs a parameter `component` which specifies which version component should be increased.
+This is either `minor` (the default) or `major`.
+`major` should be picked in cases where the new version has breaking changes (for example between the `build` script and the container image).

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -15,3 +15,7 @@ It should be run if a new release is desired.
 The workflow dispatch needs a parameter `component` which specifies which version component should be increased.
 This is either `minor` (the default) or `major`.
 `major` should be picked in cases where the new version has breaking changes (for example between the `build` script and the container image).
+
+## `differential-shellcheck.yml`
+
+Finds new warnings using [shellcheck](https://www.shellcheck.net)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,15 +1,7 @@
-name: Build and Release
+name: Build
 on:
   push:
   workflow_dispatch:
-    inputs:
-      component:
-        description: 'Version component to increment (Use *minor* unless we have breaking changes)'
-        required: false
-        type: choice
-        options:
-          - minor
-          - major
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -42,7 +34,7 @@ jobs:
   release-latest:
     runs-on: ubuntu-latest
     needs: build
-    if: github.ref == 'refs/heads/main' && github.event.inputs.component == ''
+    if: github.ref == 'refs/heads/main'
     steps:
       - uses: actions/checkout@v4
       - name: tag latest
@@ -56,31 +48,4 @@ jobs:
       - name: create release
         run: |
           release="$(.github/workflows/release.sh ${{ secrets.GITHUB_TOKEN }} ${{ github.repository }} create latest "Builder (latest)")"
-          .github/workflows/release.sh ${{ secrets.GITHUB_TOKEN }} ${{ github.repository }} upload "$release" download/build
-
-  # Run for new intentional versions, bumping the major or minor version
-  release-new-version:
-    runs-on: ubuntu-latest
-    needs: build
-    if: github.ref == 'refs/heads/main' && github.event.inputs.component != ''
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - uses: actions/download-artifact@v3
-        with:
-          name: build
-          path: download
-      - run: echo Version Component to Increase is ${{ github.event.inputs.component }}
-      - name: Get Version Number
-        run: .github/workflows/bump.py ${{ github.event.inputs.component }}
-        id: bump
-      - run: echo New version number ${{ steps.bump.outputs.newVersion }}
-      - name: tag version
-        run: |
-          git tag ${{ steps.bump.outputs.newVersion }}
-          git push origin ${{ steps.bump.outputs.newVersion }}
-      - name: create release (new version)
-        run: |
-          release="$(.github/workflows/release.sh ${{ secrets.GITHUB_TOKEN }} ${{ github.repository }} create ${{ steps.bump.outputs.newVersion }} "Builder (${{ steps.bump.outputs.newVersion }})")"
           .github/workflows/release.sh ${{ secrets.GITHUB_TOKEN }} ${{ github.repository }} upload "$release" download/build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,59 @@
+name: Release
+on:
+  workflow_dispatch:
+    inputs:
+      component:
+        description: 'Version component to increment (Use *minor* unless we have breaking changes)'
+        required: false
+        type: choice
+        options:
+          - minor
+          - major
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: gardenlinux/workflow-telemetry-action@v1
+        with:
+          metric_frequency: 1
+          comment_on_pr: false
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/upload-artifact@v3
+        with:
+          name: build
+          path: build
+
+  release-new-version:
+    runs-on: ubuntu-latest
+    needs: build
+    if: github.ref == 'refs/heads/main' && github.event.inputs.component != ''
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - run: echo Version Component to Increase is ${{ github.event.inputs.component }}
+      - name: Get Version Number
+        run: .github/workflows/bump.py ${{ github.event.inputs.component }}
+        id: bump
+      - run: echo New version number ${{ steps.bump.outputs.newVersion }}
+      - name: tag container image
+        run: |
+          SHA=$(git rev-parse HEAD)
+          podman login -u token -p ${{ github.token }} ghcr.io
+          podman pull ghcr.io/${{ github.repository }}:amd64-"$SHA"
+          podman pull ghcr.io/${{ github.repository }}:arm64-"$SHA"
+          podman manifest create ghcr.io/${{ github.repository }}:${{ steps.bump.outputs.newVersion }}
+          podman manifest add ghcr.io/${{ github.repository }}:${{ steps.bump.outputs.newVersion }} ghcr.io/${{ github.repository }}:amd64-"$SHA"
+          podman manifest add ghcr.io/${{ github.repository }}:${{ steps.bump.outputs.newVersion }} ghcr.io/${{ github.repository }}:arm64-"$SHA"
+          podman manifest push ghcr.io/${{ github.repository }}:${{ steps.bump.outputs.newVersion }}
+          sed -i 's|container_image=localhost/builder|container_image=ghcr.io/${{ github.repository }}:${{ steps.bump.outputs.newVersion }}|' build
+      - name: git tag
+        run: |
+          git tag ${{ steps.bump.outputs.newVersion }}
+          git push origin ${{ steps.bump.outputs.newVersion }}
+      - name: create release (new version)
+        run: |
+          release="$(.github/workflows/release.sh ${{ secrets.GITHUB_TOKEN }} ${{ github.repository }} create ${{ steps.bump.outputs.newVersion }} "Builder (${{ steps.bump.outputs.newVersion }})")"
+          .github/workflows/release.sh ${{ secrets.GITHUB_TOKEN }} ${{ github.repository }} upload "$release" download/build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
     inputs:
       component:
         description: 'Version component to increment (Use *minor* unless we have breaking changes)'
-        required: false
+        required: true
         type: choice
         options:
           - minor

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,6 @@ on:
           - minor
           - major
 jobs:
-
   release-new-version:
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main' && github.event.inputs.component != ''
@@ -19,7 +18,7 @@ jobs:
         with:
           fetch-depth: 0
       - run: echo Version Component to Increase is ${{ github.event.inputs.component }}
-      - name: Get Version Number
+      - name: get next version number
         run: .github/workflows/bump.py ${{ github.event.inputs.component }}
         id: bump
       - run: echo New version number ${{ steps.bump.outputs.newVersion }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,24 +10,9 @@ on:
           - minor
           - major
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: gardenlinux/workflow-telemetry-action@v1
-        with:
-          metric_frequency: 1
-          comment_on_pr: false
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - uses: actions/upload-artifact@v3
-        with:
-          name: build
-          path: build
 
   release-new-version:
     runs-on: ubuntu-latest
-    needs: build
     if: github.ref == 'refs/heads/main' && github.event.inputs.component != ''
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Cleanly separate the build (push on main) and release (new version number) workflow. The build workflow should work like it did before the release workflow was introduced. The release workflow is not supposed to build a new image, but instead to take the latest built image and apply the tag of the new version to it.
