### PR TITLE
fix: temporarily use debian stable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM debian:testing AS mv_data
+FROM debian:stable AS mv_data
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends build-essential ca-certificates git
 RUN git clone --depth=1 https://github.com/gardenlinux/mv_data
 RUN make -C mv_data install
 
-FROM debian:testing AS aws-kms-pkcs11
+FROM debian:stable AS aws-kms-pkcs11
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends build-essential awscli ca-certificates cmake git libcurl4-openssl-dev libengine-pkcs11-openssl libjson-c-dev libssl-dev libp11-kit-dev libp11-dev zlib1g-dev
 RUN git clone --depth=1 --recurse-submodules -b 1.11.25 https://github.com/aws/aws-sdk-cpp
 RUN mkdir aws-sdk-cpp/.build && cd aws-sdk-cpp/.build && cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF -DBUILD_ONLY="kms;acm-pca" .. && make -j "$(nproc)" install
@@ -11,7 +11,7 @@ RUN git clone --depth=1 -b v0.0.10 https://github.com/gardenlinux/aws-kms-pkcs11
 RUN cd aws-kms-pkcs11 && make -j "$(nproc)" AWS_SDK_STATIC=y install
 RUN cp "/usr/lib/$(uname -m)-linux-gnu/pkcs11/aws_kms_pkcs11.so" /aws_kms_pkcs11.so
 
-FROM debian:testing
+FROM debian:stable
 
 LABEL org.opencontainers.image.source="https://github.com/gardenlinux/builder"
 LABEL org.opencontainers.image.description="Builder for Garden Linux"


### PR DESCRIPTION
openssl in testing breaks aws kms pkcs11 module support