### PR TITLE
Make tempfs size configurable via new 'build.config' file

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,6 +29,11 @@ jobs:
         with:
           name: build
           path: build
+      - uses: actions/upload-artifact@v3
+        with:
+          name: build.config
+          path: build.config
+
 
   # Run for new commits on the main branch
   release-latest:
@@ -49,3 +54,4 @@ jobs:
         run: |
           release="$(.github/workflows/release.sh ${{ secrets.GITHUB_TOKEN }} ${{ github.repository }} create latest "Builder (latest)")"
           .github/workflows/release.sh ${{ secrets.GITHUB_TOKEN }} ${{ github.repository }} upload "$release" download/build
+          .github/workflows/release.sh ${{ secrets.GITHUB_TOKEN }} ${{ github.repository }} upload "$release" download/build.config

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,3 +41,4 @@ jobs:
         run: |
           release="$(.github/workflows/release.sh ${{ secrets.GITHUB_TOKEN }} ${{ github.repository }} create ${{ steps.bump.outputs.newVersion }} "Builder (${{ steps.bump.outputs.newVersion }})")"
           .github/workflows/release.sh ${{ secrets.GITHUB_TOKEN }} ${{ github.repository }} upload "$release" build
+          .github/workflows/release.sh ${{ secrets.GITHUB_TOKEN }} ${{ github.repository }} upload "$release" build.config

--- a/build
+++ b/build
@@ -7,6 +7,9 @@ container_image=localhost/builder
 container_engine=podman
 target_dir=.build
 
+SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+readonly SCRIPT_DIR
+
 container_run_opts=(
 	--security-opt seccomp=unconfined
 	--security-opt apparmor=unconfined
@@ -113,6 +116,15 @@ if [ "$use_kms" = 1 ]; then
 		fi
 	done
 fi
+
+# Default values which can be overriden via 'build.config' file
+tempfs_size=2G
+
+if [[ -f "$SCRIPT_DIR"/build.config ]]; then
+	. "$SCRIPT_DIR"/build.config
+fi
+
+make_opts+=("TEMPFS_SIZE=$tempfs_size")
 
 if [ -d cert ]; then
 	container_mount_opts+=(-v "$PWD/cert:/builder/cert:ro")

--- a/build
+++ b/build
@@ -7,9 +7,6 @@ container_image=localhost/builder
 container_engine=podman
 target_dir=.build
 
-SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
-readonly SCRIPT_DIR
-
 container_run_opts=(
 	--security-opt seccomp=unconfined
 	--security-opt apparmor=unconfined
@@ -120,8 +117,8 @@ fi
 # Default values which can be overriden via 'build.config' file
 tempfs_size=2G
 
-if [[ -f "$SCRIPT_DIR"/build.config ]]; then
-	. "$SCRIPT_DIR"/build.config
+if [[ -f "$PWD"/build.config ]]; then
+	. "$PWD"/build.config
 fi
 
 make_opts+=("TEMPFS_SIZE=$tempfs_size")

--- a/build.config
+++ b/build.config
@@ -1,0 +1,6 @@
+# This file will be sourced by the 'build' script, it needs to follow bash syntax.
+# Don't add any new code/variables here, this file's purpose is to make build variables configurable.
+
+# Size of tempfs for the builder. Might need to be increased for images with many packages.
+# If this is too small, you will see messages like 'failed to write (No space left on device)' while building the image.
+tempfs_size=2G

--- a/builder/Makefile
+++ b/builder/Makefile
@@ -21,7 +21,7 @@ $$(error '$1 undefined')
 endif
 endef
 
-required_vars := REPO COMMIT TIMESTAMP DEFAULT_VERSION
+required_vars := REPO COMMIT TIMESTAMP DEFAULT_VERSION TEMPFS_SIZE
 $(foreach var,$(required_vars),$(eval $(call require_var,$(var))))
 
 SHORT_COMMIT := $(shell head -c 8 <<< '$(COMMIT)')

--- a/builder/bootstrap
+++ b/builder/bootstrap
@@ -9,7 +9,7 @@ keyring="$(realpath "$4")"
 output="$5"
 
 chroot_dir="$(mktemp -d)"
-mount -t tmpfs -o size=2G tmpfs "$chroot_dir"
+mount -t tmpfs -o size="$TEMPFS_SIZE" tmpfs "$chroot_dir"
 chmod 755 "$chroot_dir"
 container=lxc debootstrap --keyring "$keyring" --arch "$arch" --variant minbase "$version" "$chroot_dir" "$repo" trixie || (cat "$chroot_dir/debootstrap/debootstrap.log"; false)
 

--- a/builder/configure
+++ b/builder/configure
@@ -9,7 +9,7 @@ output="$3"
 IFS=',' read -r -a features <<< "$BUILDER_FEATURES"
 
 chroot_dir="$(mktemp -d)"
-mount -t tmpfs -o size=2G tmpfs "$chroot_dir"
+mount -t tmpfs -o size="$TEMPFS_SIZE" tmpfs "$chroot_dir"
 chmod 755 "$chroot_dir"
 chcon system_u:object_r:unlabeled_t:s0 "$chroot_dir"
 

--- a/builder/configure_nativetools
+++ b/builder/configure_nativetools
@@ -9,7 +9,7 @@ shift 2
 touch "$output"
 
 chroot_dir="$(mktemp -d)"
-mount -t tmpfs -o size=2G tmpfs "$chroot_dir"
+mount -t tmpfs -o size="$TEMPFS_SIZE" tmpfs "$chroot_dir"
 chmod 755 "$chroot_dir"
 chcon system_u:object_r:unlabeled_t:s0 "$chroot_dir"
 

--- a/builder/image
+++ b/builder/image
@@ -35,7 +35,7 @@ echo "---------------"
 
 image="$(mktemp -u)"
 chroot_dir="$(mktemp -d)"
-mount -t tmpfs -o size=2G tmpfs "$chroot_dir"
+mount -t tmpfs -o size="$TEMPFS_SIZE" tmpfs "$chroot_dir"
 tar --extract --xattrs --xattrs-include '*' --directory "$chroot_dir" < "$input"
 
 (export PATH="/builder/image.d:$PATH"; makepart "$chroot_dir" < "$fstab" | makedisk "$chroot_dir" "$image")

--- a/builder/image.d/makepart
+++ b/builder/image.d/makepart
@@ -9,7 +9,7 @@ exec 1>&2
 rootfs="$1"
 
 rootfs_work=$(mktemp -d)
-mount -t tmpfs -o size=2G tmpfs "$rootfs_work"
+mount -t tmpfs -o size="$TEMPFS_SIZE" tmpfs "$rootfs_work"
 cp -a "$rootfs/." "$rootfs_work"
 
 fstab="$(mktemp)"
@@ -143,7 +143,7 @@ sed 's/#.*//;/^[[:space:]]*$/d' \
 			[ ! -e "$rootfs/builder" ]
 			mkdir "$rootfs/builder"
 			mount --rbind --make-rprivate /builder "$rootfs/builder"
-			mount -t tmpfs -o size=2G none "$rootfs/tmp"
+			mount -t tmpfs -o size="$TEMPFS_SIZE" none "$rootfs/tmp"
 			[[ "$data_source" == /tmp* ]]
 			[ "$(dirname "$file")" = /tmp ]
 			mkdir -p "$rootfs$data_source"

--- a/builder/image.d/makesecureboot
+++ b/builder/image.d/makesecureboot
@@ -69,7 +69,7 @@ mount --rbind /dev "$rootfs/dev"
 kernel_file=$(find "$rootfs/boot/" -name 'vmlinuz-*')
 kernel_version="${kernel_file#*-}"
 
-unshare --user --map-root-user --mount -- bash -c 'mount -t tmpfs -o size=2G tmpfs '"$rootfs/var/tmp"' && mount -t tmpfs -o size=2G tmpfs /sys && mount --bind /usr/bin/false /usr/bin/systemd-detect-virt && "$@"' -- \
+unshare --user --map-root-user --mount -- bash -c 'mount -t tmpfs -o size="$TEMPFS_SIZE" tmpfs '"$rootfs/var/tmp"' && mount -t tmpfs -o size="$TEMPFS_SIZE" tmpfs /sys && mount --bind /usr/bin/false /usr/bin/systemd-detect-virt && "$@"' -- \
 chroot "$rootfs" env dracut \
 	--no-hostonly \
 	--force \

--- a/builder/image.d/makesecureboot
+++ b/builder/image.d/makesecureboot
@@ -69,7 +69,7 @@ mount --rbind /dev "$rootfs/dev"
 kernel_file=$(find "$rootfs/boot/" -name 'vmlinuz-*')
 kernel_version="${kernel_file#*-}"
 
-unshare --user --map-root-user --mount -- bash -c 'mount -t tmpfs -o size="$TEMPFS_SIZE" tmpfs '"$rootfs/var/tmp"' && mount -t tmpfs -o size="$TEMPFS_SIZE" tmpfs /sys && mount --bind /usr/bin/false /usr/bin/systemd-detect-virt && "$@"' -- \
+unshare --user --map-root-user --mount -- bash -c 'mount -t tmpfs -o size='"$TEMPFS_SIZE"' tmpfs '"$rootfs/var/tmp"' && mount -t tmpfs -o size='"$TEMPFS_SIZE"' tmpfs /sys && mount --bind /usr/bin/false /usr/bin/systemd-detect-virt && "$@"' -- \
 chroot "$rootfs" env dracut \
 	--no-hostonly \
 	--force \


### PR DESCRIPTION
In some cases, the current hard-coded size limit for tempfs makes it impossible to build images with the builder. This change introduces a new config interface via a 'build.config' file which builder users might use to override selected variables.

Note that this introduces a *breaking change* in the sense that the `build` script needs to define the `tempfs_size` variable like in this example

```
# Default values which can be overriden via 'build.config' file
tempfs_size=2G

if [[ -f "$PWD"/build.config ]]; then
	. "$PWD"/build.config
fi

make_opts+=("TEMPFS_SIZE=$tempfs_size")
```

If this is not done, an error like `Makefile:25: *** 'TEMPFS_SIZE undefined'.  Stop.` will occur.

Fixes #54

Needed for https://github.com/gardenlinux/dev-image/pull/3