### PR TITLE
fix: rebuild local docker file in local development case

### DIFF
--- a/build
+++ b/build
@@ -81,8 +81,8 @@ if [ "$container_image" = localhost/builder ]; then
 	# Build from 'builder.dockerfile' if that exists, otherwise the default file name will be 'Dockerfile' or 'Containerfile'.
 	# It is recommended to call the file 'builder.dockerfile' to make it's intention clear.
 	# That file might only contain a single line 'FROM ghcr.io/gardenlinux/builder:...' which can be updated via dependabot.
-	if [[ -f builder.dockerfile ]]; then
-		"$container_engine" build -t "$container_image" -f builder.dockerfile "$dir"
+	if [[ -f "${dir}"/builder.dockerfile ]]; then
+		"$container_engine" build -t "$container_image" -f "${dir}"/builder.dockerfile "$dir"
 	else 
 		"$container_engine" build -t "$container_image" "$dir"
 	fi


### PR DESCRIPTION
In order to use a local dev version of the builder, the documentation tells the user to do the following:
```
cd gardenlinux
ln -f -s ../builder/build build
```
Furthermore, the docs suggest that the builder would re-build the docker file if necessary. 

However, this is currently not working because the link detects the gardenlinux/builder.dockerfile and uses it instead of the local builder.
