### PR TITLE
Print graph of feature dependencies

### DIFF
--- a/builder/parse_features
+++ b/builder/parse_features
@@ -32,7 +32,7 @@ def main():
 		"elements",
 		"arch",
 		"version",
-        "graph"
+		"graph"
 	]
 
 	parser.add_argument("type", nargs="?", choices=args_type_allowed, default="cname")
@@ -113,7 +113,7 @@ def main():
 		print(",".join(features_by_type["flag"]))
 	elif args.type == "graph":
 		networkx.draw(graph, with_labels = True)
-		plt.savefig('features.png')
+		plt.savefig(f"{cname_base}.png")
 		print(graph)
 
 def get_local_bin(name):

--- a/builder/parse_features
+++ b/builder/parse_features
@@ -9,7 +9,6 @@ from glob import glob
 import yaml
 import networkx
 
-
 def main():
 	parser = argparse.ArgumentParser()
 

--- a/builder/parse_features
+++ b/builder/parse_features
@@ -8,6 +8,8 @@ from functools import reduce
 from glob import glob
 import yaml
 import networkx
+import matplotlib.pyplot as plt
+
 
 def main():
 	parser = argparse.ArgumentParser()
@@ -29,7 +31,8 @@ def main():
 		"flags",
 		"elements",
 		"arch",
-		"version"
+		"version",
+        "graph"
 	]
 
 	parser.add_argument("type", nargs="?", choices=args_type_allowed, default="cname")
@@ -108,6 +111,10 @@ def main():
 		print(",".join(features_by_type["element"]))
 	elif args.type == "flags":
 		print(",".join(features_by_type["flag"]))
+	elif args.type == "graph":
+		networkx.draw(graph, with_labels = True)
+		plt.savefig('features.png')
+		print(graph)
 
 def get_local_bin(name):
 	directory = os.path.dirname(os.path.realpath(__file__))

--- a/builder/parse_features
+++ b/builder/parse_features
@@ -8,7 +8,6 @@ from functools import reduce
 from glob import glob
 import yaml
 import networkx
-import matplotlib.pyplot as plt
 
 
 def main():
@@ -112,9 +111,20 @@ def main():
 	elif args.type == "flags":
 		print(",".join(features_by_type["flag"]))
 	elif args.type == "graph":
-		networkx.draw(graph, with_labels = True)
-		plt.savefig(f"{cname_base}.png")
-		print(graph)
+		print(graph_as_mermaid_markup(cname_base, graph))
+
+def graph_as_mermaid_markup(cname_base, graph):
+	"""
+	Generates a mermaid.js representation of the graph.
+	This is helpful to identify dependencies between features.
+
+	Syntax docs:
+	https://mermaid.js.org/syntax/flowchart.html?id=flowcharts-basic-syntax
+	"""
+	markup = f"---\ntitle: Dependency Graph for Feature {cname_base}\n---\ngraph TD;\n"
+	for u,v in networkx.edges(graph):
+		markup += f"    {u}-->{v};\n"
+	return markup
 
 def get_local_bin(name):
 	directory = os.path.dirname(os.path.realpath(__file__))


### PR DESCRIPTION
This adds a new 'graph' command to `parse_features`.
This command prints the text representation of a [mermaid js](https://mermaid.js.org/syntax/flowchart.html?id=flowcharts-basic-syntax) flowchart/graph.
This output can be embedded into [GitHub flavoured markdown](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-diagrams) files.

I used the following command to run the script:

```
builder/builder/parse_features  --feature-dir gardenlinux/features/ --arch `dpkg --print-architecture` --version today --cname kvm graph
```

where the `cname` argument can be any feature.
