### PR TITLE
Pre-calculate and sign `PCR 11` values on build

### DIFF
--- a/builder/image.d/make_repart_disk
+++ b/builder/image.d/make_repart_disk
@@ -34,3 +34,10 @@ cat > "$target/etc/systemd/system/systemd-veritysetup@.service.d/override.conf" 
 [Unit]
 Before=systemd-repart.service
 EOF
+
+mkdir -p "$target/etc/systemd/system/systemd-pcrphase-initrd.service.d"
+cat > "$target/etc/systemd/system/systemd-pcrphase-initrd.service.d/override.conf" << EOF
+[Unit]
+After=sys-devices-platform-MSFT0101:00-tpm-tpm0.device
+Requires=sys-devices-platform-MSFT0101:00-tpm-tpm0.device
+EOF

--- a/builder/image.d/make_repart_disk
+++ b/builder/image.d/make_repart_disk
@@ -25,7 +25,7 @@ Before=initrd-root-device.target systemd-fsck-root.service
 
 [Service]
 ExecStart=
-ExecStart=/usr/bin/systemd-repart --root=/ --factory-reset=yes --dry-run=no --tpm2-device=auto --tpm2-pcrs=7+11 $dev_path
+ExecStart=/usr/bin/systemd-repart --root=/ --factory-reset=yes --dry-run=no --tpm2-device=auto $dev_path
 ExecStartPost=/usr/bin/udevadm settle
 EOF
 

--- a/builder/image.d/makepart
+++ b/builder/image.d/makepart
@@ -24,7 +24,7 @@ partitions="$(mktemp)"
 final_partition="$(mktemp)"
 secureboot_partitions="$(mktemp)"
 efi_partition="$(mktemp)"
-tpm_used="$(mktemp)"
+tpm2_used="$(mktemp)"
 
 part_num=0
 
@@ -103,7 +103,7 @@ sed 's/#.*//;/^[[:space:]]*$/d' \
 	fi
 
 	if [[ "$tpm2" = 1 ]]; then
-		echo 1 > "$tpm_used"
+		echo 1 > "$tpm2_used"
 	fi
 
 	if [[ "$depth" = 0 ]]; then
@@ -265,9 +265,9 @@ if [[ -z "$(cat "$root_hash")" ]]; then
 	fi
 
 	secureboot_flags=()
-	if [ -n "$(cat "$tpm_used")" ]; then
+	if [ -n "$(cat "$tpm2_used")" ]; then
 		mkdir -p "$dracut_include/usr/lib/sysusers.d"
-		echo "u tss - \"TPM software stack\" /var/lib/tpm /bin/false" > "$dracut_include/usr/lib/sysusers.d/tpm2-tss.conf"
+		echo "u tss - \"TPM2 software stack\" /var/lib/tpm /bin/false" > "$dracut_include/usr/lib/sysusers.d/tpm2-tss.conf"
 
 		secureboot_flags+=("--tpm2")
 	fi
@@ -291,5 +291,5 @@ fi
 cat "$partitions" "$final_partition" >&3
 
 # cleanup
-rm "$fstab" "$veritytab" "$root_hash" "$root_repart" "$partitions" "$final_partition" "$secureboot_partitions" "$tpm_used"
+rm "$fstab" "$veritytab" "$root_hash" "$root_repart" "$partitions" "$final_partition" "$secureboot_partitions" "$tpm2_used"
 rm -rf "$dracut_include"

--- a/builder/image.d/makesecureboot
+++ b/builder/image.d/makesecureboot
@@ -105,118 +105,133 @@ case "$BUILDER_ARCH" in
 		;;
 esac
 
-unified_image_tmp="$(mktemp)"
-pcr_tmp="$(mktemp)"
+if [[ "$secureboot" = "true" ]] || [[ -n "$tpm2" ]]; then
+	if [ -f "$cert_base.key" ]; then
+		sbs_key_params=(--key "$cert_base.key")
+		pcr_key_params=(-sign "$cert_base.key")
+	elif [ -f "$cert_base.arn" ]; then
+		PKCS11_MODULE_PATH="/usr/lib/$(uname -m)-linux-gnu/pkcs11/aws_kms_pkcs11.so"
+		PKCS11_ARN="pkcs11:token=$(basename "$(cat "$cert_base.arn")" | cut -c -32)"
+		export PKCS11_MODULE_PATH
+		sbs_key_params=(--engine pkcs11 --key $PKCS11_ARN)
+		pcr_key_params=(-keyform engine -engine pkcs11 -sign $PKCS11_ARN)
+	else
+		echo "neither $cert_base.key nor $cert_base.arn exists, but at least one is required" >&2
+		exit 1
+	fi
+fi
 
-pcr_pub_key="/builder/cert/tpm2-pcr-public.pem"
-pcr_priv_key="/builder/cert/tpm2-pcr-private.pem"
+if [[ -n "$tpm2" ]]; then
+	unified_image_tmp="$(mktemp)"
+	pcr_tmp="$(mktemp)"
 
-# pre-calculate PCR11 values
-/usr/lib/systemd/ukify build \
-	--stub "$rootfs/usr/lib/systemd/boot/efi/linux$(tr '[:upper:]' '[:lower:]' <<< "$uefi_arch").efi.stub" \
-	--linux "$kernel_file" \
-	--initrd "$initrd" \
-	--cmdline "$cmdline" \
-	--output "$unified_image_tmp" \
-	--os-release "@$rootfs/etc/os-release" \
-	--pcrpkey "$pcr_pub_key" \
-	--pcr-banks "sha256" \
-	--measure > "$pcr_tmp"
-	# TODO: replace ukify with systemd-measure
+	pcr_pub_key="$(mktemp)"
+	openssl x509 -pubkey -noout -in "$cert_base.crt" > $pcr_pub_key
 
-# generate .pcrsig section
-# [1]: https://uapi-group.org/specifications/specs/unified_kernel_image/
-# [2]: https://www.freedesktop.org/software/systemd/man/latest/systemd-measure.html#sign
-pcr_sig="$(mktemp)"
+	# pre-calculate PCR11 values
+	/usr/lib/systemd/ukify build \
+		--stub "$rootfs/usr/lib/systemd/boot/efi/linux$(tr '[:upper:]' '[:lower:]' <<< "$uefi_arch").efi.stub" \
+		--linux "$kernel_file" \
+		--initrd "$initrd" \
+		--cmdline "$cmdline" \
+		--output "$unified_image_tmp" \
+		--os-release "@$rootfs/etc/os-release" \
+		--pcrpkey "$pcr_pub_key" \
+		--pcr-banks "sha256" \
+		--measure > "$pcr_tmp"
+		# TODO: replace ukify with systemd-measure
 
-cat >> "$pcr_sig" << EOF
-{
-	"sha256" : [
-EOF
-
-# loop through all calculated PCR values (depending on boot phase)
-# and generate valid JSON according to specifications
-pcr_counter=0
-while read pcr_line; do
-	IFS='=' read -ra PCR <<< $pcr_line
-	echo "${PCR[1]}"
-
-	trailing_comma=$( [[ pcr_counter -eq 3 ]] && echo "" || echo "," )
-
-	# calculate the PCR policy digest
-	# [1]: https://github.com/tpm2-software/tpm2-tools/blob/master/man/tpm2_policypcr.1.md
-	# [2]: https://github.com/fishilico/shared/blob/master/python/crypto/tpm_ea_policy.py#L646
-	# [3]: https://trustedcomputinggroup.org/wp-content/uploads/TCG_TPM2_r1p59_Part3_Commands_pub.pdf#page=244
-	# [4]: https://trustedcomputinggroup.org/wp-content/uploads/TCG_TPM2_r1p59_Part1_Architecture_pub.pdf#page=113
-	policy_init=$(printf '%0*d' 64 0)
-
-	command_code="0000017f"
-	hash_alg_id="000b"
-	pcr_index="11"
-
-	pcr_value_hash=$(echo -n "${PCR[1]}" | xxd -r -p | openssl dgst -sha256 -binary | xxd -p -c 256)
-
-	pcr_select_bit_map=("00" "00" "00")
-	pcr_select_bit_map[$((pcr_index / 8))]=$(printf "%02x" $((1 << pcr_index % 8)))
-
-	pcr_selection=$(printf "00000001%s03%s%s%s" "$hash_alg_id" "${pcr_select_bit_map[0]}" "${pcr_select_bit_map[1]}" "${pcr_select_bit_map[2]}")
-
-	policy="${policy_init}${command_code}${pcr_selection}${pcr_value_hash}"
-	policy_digest=$(echo -n "$policy" | xxd -r -p | openssl dgst -sha256 -binary | xxd -p -c 256)
+	# generate .pcrsig section
+	# [1]: https://uapi-group.org/specifications/specs/unified_kernel_image/
+	# [2]: https://www.freedesktop.org/software/systemd/man/latest/systemd-measure.html#sign
+	pcr_sig="$(mktemp)"
 
 	cat >> "$pcr_sig" << EOF
-		{
-			"pcrs" : [
-				11
-			],
-			"pkfp" : "$(openssl pkey -pubin -inform PEM -outform DER -in "$pcr_pub_key" | tail -c +25 | openssl dgst -sha256 -hex | awk '{print $2}')",
-			"pol" : "$policy_digest",
-			"sig" : "$(echo -n "$policy_digest" | xxd -r -p | openssl dgst -sha256 -sign "$pcr_priv_key" | openssl base64 -A)"
-		}$trailing_comma
+	{
+		"sha256" : [
 EOF
 
-	pcr_counter=$((pcr_counter+1))
-	[[ $pcr_counter -eq 4 ]] && break
-	
-done < $pcr_tmp
+	# loop through all calculated PCR values (depending on boot phase)
+	# and generate valid JSON according to specifications
+	pcr_counter=0
+	while read pcr_line; do
+		IFS='=' read -ra PCR <<< $pcr_line
+		echo "${PCR[1]}"
 
-cat >> "$pcr_sig" << EOF
-	]
-}
+		trailing_comma=$( [[ pcr_counter -eq 3 ]] && echo "" || echo "," )
+
+		# calculate the PCR policy digest
+		# [1]: https://github.com/tpm2-software/tpm2-tools/blob/master/man/tpm2_policypcr.1.md
+		# [2]: https://github.com/fishilico/shared/blob/master/python/crypto/tpm_ea_policy.py#L646
+		# [3]: https://trustedcomputinggroup.org/wp-content/uploads/TCG_TPM2_r1p59_Part3_Commands_pub.pdf#page=244
+		# [4]: https://trustedcomputinggroup.org/wp-content/uploads/TCG_TPM2_r1p59_Part1_Architecture_pub.pdf#page=113
+		policy_init=$(printf '%0*d' 64 0)
+
+		command_code="0000017f"
+		hash_alg_id="000b"
+		pcr_index="11"
+
+		pcr_value_hash=$(echo -n "${PCR[1]}" | xxd -r -p | openssl dgst -sha256 -binary | xxd -p -c 256)
+
+		pcr_select_bit_map=("00" "00" "00")
+		pcr_select_bit_map[$((pcr_index / 8))]=$(printf "%02x" $((1 << pcr_index % 8)))
+
+		pcr_selection=$(printf "00000001%s03%s%s%s" "$hash_alg_id" "${pcr_select_bit_map[0]}" "${pcr_select_bit_map[1]}" "${pcr_select_bit_map[2]}")
+
+		policy="${policy_init}${command_code}${pcr_selection}${pcr_value_hash}"
+		policy_digest=$(echo -n "$policy" | xxd -r -p | openssl dgst -sha256 -binary | xxd -p -c 256)
+
+		cat >> "$pcr_sig" << EOF
+			{
+				"pcrs" : [
+					11
+				],
+				"pkfp" : "$(openssl pkey -pubin -inform PEM -outform DER -in "$pcr_pub_key" | tail -c +25 | openssl dgst -sha256 -hex | awk '{print $2}')",
+				"pol" : "$policy_digest",
+				"sig" : "$(echo -n "$policy_digest" | xxd -r -p | openssl dgst -sha256 "${pcr_key_params[@]}" | openssl base64 -A)"
+			}$trailing_comma
 EOF
 
-# create unified image and append generated .pcrsig section
-/usr/lib/systemd/ukify build \
+		pcr_counter=$((pcr_counter+1))
+		[[ $pcr_counter -eq 4 ]] && break
+		
+	done < $pcr_tmp
+
+	cat >> "$pcr_sig" << EOF
+		]
+	}
+EOF
+
+	# create unified image and append generated .pcrsig section
+	/usr/lib/systemd/ukify build \
+		--stub "$rootfs/usr/lib/systemd/boot/efi/linux$(tr '[:upper:]' '[:lower:]' <<< "$uefi_arch").efi.stub" \
+		--linux "$kernel_file" \
+		--initrd "$initrd" \
+		--cmdline "$cmdline" \
+		--output "$unified_image" \
+		--os-release "@$rootfs/etc/os-release" \
+		--pcrpkey "$pcr_pub_key" \
+		--section ".pcrsig:@$pcr_sig"
+
+	rm $unified_image_tmp
+	rm $pcr_tmp
+	rm $pcr_sig
+else
+	/usr/lib/systemd/ukify build \
 	--stub "$rootfs/usr/lib/systemd/boot/efi/linux$(tr '[:upper:]' '[:lower:]' <<< "$uefi_arch").efi.stub" \
 	--linux "$kernel_file" \
 	--initrd "$initrd" \
 	--cmdline "$cmdline" \
 	--output "$unified_image" \
-	--os-release "@$rootfs/etc/os-release" \
-	--pcrpkey "$pcr_pub_key" \
-	--section ".pcrsig:@$pcr_sig"
-
-rm $unified_image_tmp
-rm $pcr_tmp
-rm $pcr_sig
+	--os-release "@$rootfs/etc/os-release"
+fi
 
 efi_dir="$(mktemp -d)"
 mkdir -p "$efi_dir/EFI/BOOT/"
 
 if [[ "$secureboot" = "true" ]]; then
-	if [ -f "$cert_base.key" ]; then
-		key_params=(--key "$cert_base.key")
-	elif [ -f "$cert_base.arn" ]; then
-		PKCS11_MODULE_PATH="/usr/lib/$(uname -m)-linux-gnu/pkcs11/aws_kms_pkcs11.so"
-		export PKCS11_MODULE_PATH
-		key_params=(--engine pkcs11 --key "pkcs11:token=$(basename "$(cat "$cert_base.arn")" | cut -c -32)")
-	else
-		echo "neither $cert_base.key nor $cert_base.arn exists, but at least one is required" >&2
-		exit 1
-	fi
-
 	# sign unified image
-	datefudge -s "@$timestamp" sbsign --cert "$cert_base.crt" "${key_params[@]}" --output "$unified_image_signed" "$unified_image"
+	datefudge -s "@$timestamp" sbsign --cert "$cert_base.crt" "${sbs_key_params[@]}" --output "$unified_image_signed" "$unified_image"
 	rm "$unified_image"
 
 	ls -lah "$unified_image_signed"

--- a/builder/image.d/makesecureboot
+++ b/builder/image.d/makesecureboot
@@ -4,7 +4,7 @@ set -Eeufo pipefail
 
 veritytab=
 cert_base="/builder/cert/secureboot.db"
-tpm_sign_base="/builder/cert/tpm-sign"
+tpm2_sign_base="/builder/cert/tpm-sign"
 timestamp=0
 secureboot="true"
 dracut_include=
@@ -44,9 +44,9 @@ while [ $# -gt 0 ]; do
 			tpm2="tpm2-tss"
 			shift
 			;;
-		--tpm-sign)
-			tpm_sign_base="${2%.crt}"
-			if [ -n "$tpm_sign_base" ] && [ "$tpm_sign_base.crt" != "$2" ]; then
+		--tpm2-sign)
+			tpm2_sign_base="${2%.crt}"
+			if [ -n "$tpm2_sign_base" ] && [ "$tpm2_sign_base.crt" != "$2" ]; then
 				echo "cert file must end in .crt" >&2
 				exit 1
 			fi
@@ -118,12 +118,12 @@ PKCS11_MODULE_PATH="/usr/lib/$(uname -m)-linux-gnu/pkcs11/aws_kms_pkcs11.so"
 export PKCS11_MODULE_PATH
 
 if [[ -n "$tpm2" ]]; then
-	if [ -f "$tpm_sign_base.key" ]; then
-		pcr_key_params=(-sign "$tpm_sign_base.key")
-	elif [ -f "$tpm_sign_base.arn" ]; then
-		pcr_key_params=(-keyform engine -engine pkcs11 -sign "pkcs11:token=$(basename "$(cat "$tpm_sign_base.arn")" | cut -c -32)")
+	if [ -f "$tpm2_sign_base.key" ]; then
+		pcr_key_params=(-sign "$tpm2_sign_base.key")
+	elif [ -f "$tpm2_sign_base.arn" ]; then
+		pcr_key_params=(-keyform engine -engine pkcs11 -sign "pkcs11:token=$(basename "$(cat "$tpm2_sign_base.arn")" | cut -c -32)")
 	else
-		echo "neither $tpm_sign_base.key nor $tpm_sign_base.arn exists, but at least one is required" >&2
+		echo "neither $tpm2_sign_base.key nor $tpm2_sign_base.arn exists, but at least one is required" >&2
 		exit 1
 	fi
 
@@ -131,7 +131,7 @@ if [[ -n "$tpm2" ]]; then
 	pcr_tmp="$(mktemp)"
 
 	pcr_pub_key="$(mktemp)"
-	openssl x509 -pubkey -noout -in "$tpm_sign_base.crt" > $pcr_pub_key
+	openssl x509 -pubkey -noout -in "$tpm2_sign_base.crt" > $pcr_pub_key
 
 	# pre-calculate PCR11 values
 	/usr/lib/systemd/ukify build \

--- a/builder/image.d/makesecureboot
+++ b/builder/image.d/makesecureboot
@@ -105,14 +105,13 @@ case "$BUILDER_ARCH" in
 		;;
 esac
 
-# pre-calculate PCR11 values
 unified_image_tmp="$(mktemp)"
 pcr_tmp="$(mktemp)"
 
 pcr_pub_key="/builder/cert/tpm2-pcr-public.pem"
 pcr_priv_key="/builder/cert/tpm2-pcr-private.pem"
 
-# TODO: replace ukify with systemd-measure
+# pre-calculate PCR11 values
 /usr/lib/systemd/ukify build \
 	--stub "$rootfs/usr/lib/systemd/boot/efi/linux$(tr '[:upper:]' '[:lower:]' <<< "$uefi_arch").efi.stub" \
 	--linux "$kernel_file" \
@@ -123,8 +122,11 @@ pcr_priv_key="/builder/cert/tpm2-pcr-private.pem"
 	--pcrpkey "$pcr_pub_key" \
 	--pcr-banks "sha256" \
 	--measure > "$pcr_tmp"
+	# TODO: replace ukify with systemd-measure
 
 # generate .pcrsig section
+# [1]: https://uapi-group.org/specifications/specs/unified_kernel_image/
+# [2]: https://www.freedesktop.org/software/systemd/man/latest/systemd-measure.html#sign
 pcr_sig="$(mktemp)"
 
 cat >> "$pcr_sig" << EOF
@@ -132,15 +134,16 @@ cat >> "$pcr_sig" << EOF
 	"sha256" : [
 EOF
 
+# loop through all calculated PCR values (depending on boot phase)
+# and generate valid JSON according to specifications
 pcr_counter=0
 while read pcr_line; do
-	# Split the string at the "="
 	IFS='=' read -ra PCR <<< $pcr_line
 	echo "${PCR[1]}"
 
 	trailing_comma=$( [[ pcr_counter -eq 3 ]] && echo "" || echo "," )
 
-	# Calculate the PCR policy digest
+	# calculate the PCR policy digest
 	# [1]: https://github.com/tpm2-software/tpm2-tools/blob/master/man/tpm2_policypcr.1.md
 	# [2]: https://github.com/fishilico/shared/blob/master/python/crypto/tpm_ea_policy.py#L646
 	# [3]: https://trustedcomputinggroup.org/wp-content/uploads/TCG_TPM2_r1p59_Part3_Commands_pub.pdf#page=244
@@ -183,7 +186,7 @@ cat >> "$pcr_sig" << EOF
 }
 EOF
 
-# create unified image
+# create unified image and append generated .pcrsig section
 /usr/lib/systemd/ukify build \
 	--stub "$rootfs/usr/lib/systemd/boot/efi/linux$(tr '[:upper:]' '[:lower:]' <<< "$uefi_arch").efi.stub" \
 	--linux "$kernel_file" \

--- a/builder/image.d/makesecureboot
+++ b/builder/image.d/makesecureboot
@@ -114,23 +114,19 @@ case "$BUILDER_ARCH" in
 		;;
 esac
 
-if [[ "$secureboot" = "true" ]] || [[ -n "$tpm2" ]]; then
-	if [ -f "$cert_base.key" ]; then
-		sbs_key_params=(--key "$cert_base.key")
-		pcr_key_params=(-sign "$cert_base.key")
-	elif [ -f "$cert_base.arn" ]; then
-		PKCS11_MODULE_PATH="/usr/lib/$(uname -m)-linux-gnu/pkcs11/aws_kms_pkcs11.so"
-		export PKCS11_MODULE_PATH
-		
-		sbs_key_params=(--engine pkcs11 --key "pkcs11:token=$(basename "$(cat "$cert_base.arn")" | cut -c -32)")
-		pcr_key_params=(-keyform engine -engine pkcs11 -sign "pkcs11:token=$(basename "$(cat "$tpm_sign_base.arn")" | cut -c -32)")
-	else
-		echo "neither $cert_base.key nor $cert_base.arn exists, but at least one is required" >&2
-		exit 1
-	fi
-fi
+PKCS11_MODULE_PATH="/usr/lib/$(uname -m)-linux-gnu/pkcs11/aws_kms_pkcs11.so"
+export PKCS11_MODULE_PATH
 
 if [[ -n "$tpm2" ]]; then
+	if [ -f "$tpm_sign_base.key" ]; then
+		pcr_key_params=(-sign "$tpm_sign_base.key")
+	elif [ -f "$tpm_sign_base.arn" ]; then
+		pcr_key_params=(-keyform engine -engine pkcs11 -sign "pkcs11:token=$(basename "$(cat "$tpm_sign_base.arn")" | cut -c -32)")
+	else
+		echo "neither $tpm_sign_base.key nor $tpm_sign_base.arn exists, but at least one is required" >&2
+		exit 1
+	fi
+
 	unified_image_tmp="$(mktemp)"
 	pcr_tmp="$(mktemp)"
 
@@ -230,6 +226,7 @@ EOF
 	rm $unified_image_tmp
 	rm $pcr_tmp
 	rm $pcr_sig
+	rm $pcr_pub_key
 else
 	/usr/lib/systemd/ukify build \
 	--stub "$rootfs/usr/lib/systemd/boot/efi/linux$(tr '[:upper:]' '[:lower:]' <<< "$uefi_arch").efi.stub" \
@@ -244,6 +241,15 @@ efi_dir="$(mktemp -d)"
 mkdir -p "$efi_dir/EFI/BOOT/"
 
 if [[ "$secureboot" = "true" ]]; then
+	if [ -f "$cert_base.key" ]; then
+		sbs_key_params=(--key "$cert_base.key")
+	elif [ -f "$cert_base.arn" ]; then
+		sbs_key_params=(--engine pkcs11 --key "pkcs11:token=$(basename "$(cat "$cert_base.arn")" | cut -c -32)")
+	else
+		echo "neither $cert_base.key nor $cert_base.arn exists, but at least one is required" >&2
+		exit 1
+	fi
+
 	# sign unified image
 	datefudge -s "@$timestamp" sbsign --cert "$cert_base.crt" "${sbs_key_params[@]}" --output "$unified_image_signed" "$unified_image"
 	rm "$unified_image"

--- a/builder/image.d/makesecureboot
+++ b/builder/image.d/makesecureboot
@@ -131,7 +131,7 @@ if [[ -n "$tpm2" ]]; then
 	pcr_tmp="$(mktemp)"
 
 	pcr_pub_key="$(mktemp)"
-	openssl x509 -pubkey -noout -in "$tpm2_sign_base.crt" > $pcr_pub_key
+	openssl x509 -pubkey -noout -in "$tpm2_sign_base.crt" > "$pcr_pub_key"
 
 	# pre-calculate PCR11 values
 	/usr/lib/systemd/ukify build \
@@ -159,8 +159,8 @@ EOF
 	# loop through all calculated PCR values (depending on boot phase)
 	# and generate valid JSON according to specifications
 	pcr_counter=0
-	while read pcr_line; do
-		IFS='=' read -ra PCR <<< $pcr_line
+	while read -r pcr_line; do
+		IFS='=' read -ra PCR <<< "$pcr_line"
 		echo "${PCR[1]}"
 
 		trailing_comma=$( [[ pcr_counter -eq 3 ]] && echo "" || echo "," )
@@ -179,7 +179,7 @@ EOF
 		pcr_value_hash=$(echo -n "${PCR[1]}" | xxd -r -p | openssl dgst -sha256 -binary | xxd -p -c 256)
 
 		pcr_select_bit_map=("00" "00" "00")
-		pcr_select_bit_map[$((pcr_index / 8))]=$(printf "%02x" $((1 << pcr_index % 8)))
+		pcr_select_bit_map[pcr_index / 8]=$(printf "%02x" $((1 << pcr_index % 8)))
 
 		pcr_selection=$(printf "00000001%s03%s%s%s" "$hash_alg_id" "${pcr_select_bit_map[0]}" "${pcr_select_bit_map[1]}" "${pcr_select_bit_map[2]}")
 
@@ -188,8 +188,8 @@ EOF
 
 		# calculate and verify the PCR signature
 		pcr_signature=$(mktemp)
-		echo -n "$policy_digest" | xxd -r -p | openssl dgst -sha256 "${pcr_key_params[@]}" -out $pcr_signature
-		echo -n "$policy_digest" | xxd -r -p | openssl dgst -sha256 -verify $pcr_pub_key -signature $pcr_signature
+		echo -n "$policy_digest" | xxd -r -p | openssl dgst -sha256 "${pcr_key_params[@]}" -out "$pcr_signature"
+		echo -n "$policy_digest" | xxd -r -p | openssl dgst -sha256 -verify "$pcr_pub_key" -signature "$pcr_signature"
 
 		cat >> "$pcr_sig" << EOF
 		{
@@ -198,14 +198,14 @@ EOF
 			],
 			"pkfp" : "$(openssl pkey -pubin -inform PEM -outform DER -in "$pcr_pub_key" | tail -c +25 | openssl dgst -sha256 -hex | awk '{print $2}')",
 			"pol" : "$policy_digest",
-			"sig" : "$(cat $pcr_signature | openssl base64 -A)"
+			"sig" : "$(cat "$pcr_signature" | openssl base64 -A)"
 		}$trailing_comma
 EOF
 
 		pcr_counter=$((pcr_counter+1))
 		[[ $pcr_counter -eq 4 ]] && break
 		
-	done < $pcr_tmp
+	done < "$pcr_tmp"
 
 	cat >> "$pcr_sig" << EOF
 	]
@@ -223,10 +223,10 @@ EOF
 		--pcrpkey "$pcr_pub_key" \
 		--section ".pcrsig:@$pcr_sig"
 
-	rm $unified_image_tmp
-	rm $pcr_tmp
-	rm $pcr_sig
-	rm $pcr_pub_key
+	rm "$unified_image_tmp"
+	rm "$pcr_tmp"
+	rm "$pcr_sig"
+	rm "$pcr_pub_key"
 else
 	/usr/lib/systemd/ukify build \
 	--stub "$rootfs/usr/lib/systemd/boot/efi/linux$(tr '[:upper:]' '[:lower:]' <<< "$uefi_arch").efi.stub" \

--- a/builder/image.d/makesecureboot
+++ b/builder/image.d/makesecureboot
@@ -198,7 +198,7 @@ EOF
 			],
 			"pkfp" : "$(openssl pkey -pubin -inform PEM -outform DER -in "$pcr_pub_key" | tail -c +25 | openssl dgst -sha256 -hex | awk '{print $2}')",
 			"pol" : "$policy_digest",
-			"sig" : "$(cat "$pcr_signature" | openssl base64 -A)"
+			"sig" : "$(openssl base64 -A -in "$pcr_signature")"
 		}$trailing_comma
 EOF
 

--- a/builder/image.d/makesecureboot
+++ b/builder/image.d/makesecureboot
@@ -128,59 +128,59 @@ pcr_sig="$(mktemp)"
 
 cat >> "$pcr_sig" << EOF
 {
-  "sha256" : [
+	"sha256" : [
 EOF
 
 pcr_counter=0
 while read pcr_line; do
-    # Split the string at the "="
-    IFS='=' read -ra PCR <<< $pcr_line
-    echo "${PCR[1]}"
+	# Split the string at the "="
+	IFS='=' read -ra PCR <<< $pcr_line
+	echo "${PCR[1]}"
 
-    if (( pcr_counter == 3 )); then
-      trailing_comma=""
-    else
-      trailing_comma=","
-    fi
+	if (( pcr_counter == 3 )); then
+		trailing_comma=""
+	else
+		trailing_comma=","
+	fi
 
-    # Calculate the PCR policy digest
-    policy_init=$(printf '%0*d' 64 0)
+	# Calculate the PCR policy digest
+	policy_init=$(printf '%0*d' 64 0)
 
-    command_code="0000017f"
-    hash_alg_id="000B"
+	command_code="0000017f"
+	hash_alg_id="000B"
 
-    pcr_index="11"
-    pcr_value_hash=$(echo -n "${PCR[1]}" | xxd -r -p | openssl dgst -sha256 -binary | xxd -p -c 256)
+	pcr_index="11"
+	pcr_value_hash=$(echo -n "${PCR[1]}" | xxd -r -p | openssl dgst -sha256 -binary | xxd -p -c 256)
 
-    pcr_select_bit_map=("00" "00" "00")
-    pcr_select_bit_map[$((pcr_index / 8))]=$(printf "%02x" $((1 << pcr_index % 8)))
+	pcr_select_bit_map=("00" "00" "00")
+	pcr_select_bit_map[$((pcr_index / 8))]=$(printf "%02x" $((1 << pcr_index % 8)))
 
-    pcr_selection=$(printf "00000001%s03%s%s%s" "$hash_alg_id" "${pcr_select_bit_map[0]}" "${pcr_select_bit_map[1]}" "${pcr_select_bit_map[2]}")
-    policy="${policy_init}$command_code$pcr_selection$pcr_value_hash"
+	pcr_selection=$(printf "00000001%s03%s%s%s" "$hash_alg_id" "${pcr_select_bit_map[0]}" "${pcr_select_bit_map[1]}" "${pcr_select_bit_map[2]}")
+	policy="${policy_init}$command_code$pcr_selection$pcr_value_hash"
 
-    policy_digest=$(echo -n "$policy" | xxd -r -p | openssl dgst -sha256 -binary | xxd -p -c 256)
-		# ***
+	policy_digest=$(echo -n "$policy" | xxd -r -p | openssl dgst -sha256 -binary | xxd -p -c 256)
+	# ***
 
-    cat >> "$pcr_sig" << EOF
-    {
-      "pcrs" : [
-        11
-      ],
-      "pkfp" : "$(openssl pkey -pubin -inform PEM -outform DER -in "$pcr_pub_key" | tail -c +25 | openssl dgst -sha256 -hex | awk '{print $2}')",
-      "pol" : "$policy_digest",
-      "sig" : "$(echo -n "$policy_digest" | xxd -r -p | openssl dgst -sha256 -sign "$pcr_priv_key" | openssl base64 -A)"
-    }$trailing_comma
+	cat >> "$pcr_sig" << EOF
+		{
+			"pcrs" : [
+				11
+			],
+			"pkfp" : "$(openssl pkey -pubin -inform PEM -outform DER -in "$pcr_pub_key" | tail -c +25 | openssl dgst -sha256 -hex | awk '{print $2}')",
+			"pol" : "$policy_digest",
+			"sig" : "$(echo -n "$policy_digest" | xxd -r -p | openssl dgst -sha256 -sign "$pcr_priv_key" | openssl base64 -A)"
+		}$trailing_comma
 EOF
 
-	  pcr_counter=$((pcr_counter+1))
+	pcr_counter=$((pcr_counter+1))
 
-    if (( pcr_counter == 4 )); then
-      break
-    fi
+	if (( pcr_counter == 4 )); then
+		break
+	fi
 done < $pcr_tmp
 
 cat >> "$pcr_sig" << EOF
-  ]
+	]
 }
 EOF
 

--- a/builder/image.d/makesecureboot
+++ b/builder/image.d/makesecureboot
@@ -151,12 +151,12 @@ while read pcr_line; do
 	command_code="0000017f"
 	hash_alg_id="000b"
 	pcr_index="11"
-	
+
 	pcr_value_hash=$(echo -n "${PCR[1]}" | xxd -r -p | openssl dgst -sha256 -binary | xxd -p -c 256)
 
 	pcr_select_bit_map=("00" "00" "00")
 	pcr_select_bit_map[$((pcr_index / 8))]=$(printf "%02x" $((1 << pcr_index % 8)))
-	
+
 	pcr_selection=$(printf "00000001%s03%s%s%s" "$hash_alg_id" "${pcr_select_bit_map[0]}" "${pcr_select_bit_map[1]}" "${pcr_select_bit_map[2]}")
 
 	policy="${policy_init}${command_code}${pcr_selection}${pcr_value_hash}"

--- a/builder/image.d/makesecureboot
+++ b/builder/image.d/makesecureboot
@@ -79,7 +79,7 @@ chroot "$rootfs" env dracut \
 	--no-hostonly \
 	--force \
 	--kver "$kernel_version" \
-	--modules "bash dash systemd systemd-initrd systemd-veritysetup systemd-repart kernel-modules kernel-modules-extra terminfo udev-rules dracut-systemd base fs-lib shutdown crypt $tpm2" \
+	--modules "bash dash systemd systemd-initrd systemd-veritysetup systemd-repart kernel-modules kernel-modules-extra terminfo udev-rules dracut-systemd base fs-lib shutdown crypt systemd-pcrphase $tpm2" \
 	--install "/etc/veritytab cryptsetup head mkfs.ext4 systemd-escape lsblk" \
 	--include "$dracut_include" "/" \
 	--reproducible \
@@ -105,13 +105,35 @@ case "$BUILDER_ARCH" in
 		;;
 esac
 
+# pre-calculation PCR11 values
+unified_image_tmp="$(mktemp)"
+pcr_tmp="$(mktemp)"
+
+/usr/lib/systemd/ukify build \
+	--stub "$rootfs/usr/lib/systemd/boot/efi/linux$(tr '[:upper:]' '[:lower:]' <<< "$uefi_arch").efi.stub" \
+	--linux "$kernel_file" \
+	--initrd "$initrd" \
+	--cmdline "$cmdline" \
+	--output "$unified_image_tmp" \
+	--os-release "@$rootfs/etc/os-release" \
+	--pcr-banks "sha256" \
+	--measure > "$pcr_tmp"
+
+read -r pcr_value < "$pcr_tmp"
+pcr_value=$(echo $pcr_value | cut -d '=' -f2)
+
+rm $unified_image_tmp
+rm $pcr_tmp
+# ***
+
 # create unified image
 /usr/lib/systemd/ukify build \
 	--stub "$rootfs/usr/lib/systemd/boot/efi/linux$(tr '[:upper:]' '[:lower:]' <<< "$uefi_arch").efi.stub" \
 	--linux "$kernel_file" \
 	--initrd "$initrd" \
 	--cmdline "$cmdline" \
-	--output "$unified_image"
+	--output "$unified_image" \
+	--os-release "@$rootfs/etc/os-release"
 
 efi_dir="$(mktemp -d)"
 mkdir -p "$efi_dir/EFI/BOOT/"

--- a/builder/image.d/makesecureboot
+++ b/builder/image.d/makesecureboot
@@ -4,6 +4,7 @@ set -Eeufo pipefail
 
 veritytab=
 cert_base="/builder/cert/secureboot.db"
+tpm_sign_base="/builder/cert/tpm-sign"
 timestamp=0
 secureboot="true"
 dracut_include=
@@ -42,6 +43,14 @@ while [ $# -gt 0 ]; do
 		--tpm2)
 			tpm2="tpm2-tss"
 			shift
+			;;
+		--tpm-sign)
+			tpm_sign_base="${2%.crt}"
+			if [ -n "$tpm_sign_base" ] && [ "$tpm_sign_base.crt" != "$2" ]; then
+				echo "cert file must end in .crt" >&2
+				exit 1
+			fi
+			shift 2
 			;;
 		-i|--include)
 			dracut_include="$2"
@@ -111,10 +120,10 @@ if [[ "$secureboot" = "true" ]] || [[ -n "$tpm2" ]]; then
 		pcr_key_params=(-sign "$cert_base.key")
 	elif [ -f "$cert_base.arn" ]; then
 		PKCS11_MODULE_PATH="/usr/lib/$(uname -m)-linux-gnu/pkcs11/aws_kms_pkcs11.so"
-		PKCS11_ARN="pkcs11:token=$(basename "$(cat "$cert_base.arn")" | cut -c -32)"
 		export PKCS11_MODULE_PATH
-		sbs_key_params=(--engine pkcs11 --key $PKCS11_ARN)
-		pcr_key_params=(-keyform engine -engine pkcs11 -sign $PKCS11_ARN)
+		
+		sbs_key_params=(--engine pkcs11 --key "pkcs11:token=$(basename "$(cat "$cert_base.arn")" | cut -c -32)")
+		pcr_key_params=(-keyform engine -engine pkcs11 -sign "pkcs11:token=$(basename "$(cat "$tpm_sign_base.arn")" | cut -c -32)")
 	else
 		echo "neither $cert_base.key nor $cert_base.arn exists, but at least one is required" >&2
 		exit 1
@@ -126,7 +135,7 @@ if [[ -n "$tpm2" ]]; then
 	pcr_tmp="$(mktemp)"
 
 	pcr_pub_key="$(mktemp)"
-	openssl x509 -pubkey -noout -in "$cert_base.crt" > $pcr_pub_key
+	openssl x509 -pubkey -noout -in "$tpm_sign_base.crt" > $pcr_pub_key
 
 	# pre-calculate PCR11 values
 	/usr/lib/systemd/ukify build \
@@ -147,8 +156,8 @@ if [[ -n "$tpm2" ]]; then
 	pcr_sig="$(mktemp)"
 
 	cat >> "$pcr_sig" << EOF
-	{
-		"sha256" : [
+{
+	"sha256" : [
 EOF
 
 	# loop through all calculated PCR values (depending on boot phase)
@@ -181,15 +190,20 @@ EOF
 		policy="${policy_init}${command_code}${pcr_selection}${pcr_value_hash}"
 		policy_digest=$(echo -n "$policy" | xxd -r -p | openssl dgst -sha256 -binary | xxd -p -c 256)
 
+		# calculate and verify the PCR signature
+		pcr_signature=$(mktemp)
+		echo -n "$policy_digest" | xxd -r -p | openssl dgst -sha256 "${pcr_key_params[@]}" -out $pcr_signature
+		echo -n "$policy_digest" | xxd -r -p | openssl dgst -sha256 -verify $pcr_pub_key -signature $pcr_signature
+
 		cat >> "$pcr_sig" << EOF
-			{
-				"pcrs" : [
-					11
-				],
-				"pkfp" : "$(openssl pkey -pubin -inform PEM -outform DER -in "$pcr_pub_key" | tail -c +25 | openssl dgst -sha256 -hex | awk '{print $2}')",
-				"pol" : "$policy_digest",
-				"sig" : "$(echo -n "$policy_digest" | xxd -r -p | openssl dgst -sha256 "${pcr_key_params[@]}" | openssl base64 -A)"
-			}$trailing_comma
+		{
+			"pcrs" : [
+				11
+			],
+			"pkfp" : "$(openssl pkey -pubin -inform PEM -outform DER -in "$pcr_pub_key" | tail -c +25 | openssl dgst -sha256 -hex | awk '{print $2}')",
+			"pol" : "$policy_digest",
+			"sig" : "$(cat $pcr_signature | openssl base64 -A)"
+		}$trailing_comma
 EOF
 
 		pcr_counter=$((pcr_counter+1))
@@ -198,8 +212,8 @@ EOF
 	done < $pcr_tmp
 
 	cat >> "$pcr_sig" << EOF
-		]
-	}
+	]
+}
 EOF
 
 	# create unified image and append generated .pcrsig section

--- a/builder/image.d/makesecureboot
+++ b/builder/image.d/makesecureboot
@@ -112,6 +112,7 @@ pcr_tmp="$(mktemp)"
 pcr_pub_key="/builder/cert/tpm2-pcr-public.pem"
 pcr_priv_key="/builder/cert/tpm2-pcr-private.pem"
 
+# TODO: replace ukify with systemd-measure
 /usr/lib/systemd/ukify build \
 	--stub "$rootfs/usr/lib/systemd/boot/efi/linux$(tr '[:upper:]' '[:lower:]' <<< "$uefi_arch").efi.stub" \
 	--linux "$kernel_file" \
@@ -137,29 +138,29 @@ while read pcr_line; do
 	IFS='=' read -ra PCR <<< $pcr_line
 	echo "${PCR[1]}"
 
-	if (( pcr_counter == 3 )); then
-		trailing_comma=""
-	else
-		trailing_comma=","
-	fi
+	trailing_comma=$( [[ pcr_counter -eq 3 ]] && echo "" || echo "," )
 
 	# Calculate the PCR policy digest
+	# [1]: https://github.com/tpm2-software/tpm2-tools/blob/master/man/tpm2_policypcr.1.md
+	# [2]: https://github.com/fishilico/shared/blob/master/python/crypto/tpm_ea_policy.py#L646
+	# [3]: https://trustedcomputinggroup.org/wp-content/uploads/TCG_TPM2_r1p59_Part3_Commands_pub.pdf#page=244
+	# [4]: https://trustedcomputinggroup.org/wp-content/uploads/TCG_TPM2_r1p59_Part1_Architecture_pub.pdf#page=113
+
 	policy_init=$(printf '%0*d' 64 0)
 
 	command_code="0000017f"
 	hash_alg_id="000B"
-
 	pcr_index="11"
+	
 	pcr_value_hash=$(echo -n "${PCR[1]}" | xxd -r -p | openssl dgst -sha256 -binary | xxd -p -c 256)
 
 	pcr_select_bit_map=("00" "00" "00")
 	pcr_select_bit_map[$((pcr_index / 8))]=$(printf "%02x" $((1 << pcr_index % 8)))
-
+	
 	pcr_selection=$(printf "00000001%s03%s%s%s" "$hash_alg_id" "${pcr_select_bit_map[0]}" "${pcr_select_bit_map[1]}" "${pcr_select_bit_map[2]}")
-	policy="${policy_init}$command_code$pcr_selection$pcr_value_hash"
 
+	policy="${policy_init}${command_code}${pcr_selection}${pcr_value_hash}"
 	policy_digest=$(echo -n "$policy" | xxd -r -p | openssl dgst -sha256 -binary | xxd -p -c 256)
-	# ***
 
 	cat >> "$pcr_sig" << EOF
 		{
@@ -173,10 +174,8 @@ while read pcr_line; do
 EOF
 
 	pcr_counter=$((pcr_counter+1))
-
-	if (( pcr_counter == 4 )); then
-		break
-	fi
+	[[ $pcr_counter -eq 4 ]] && break
+	
 done < $pcr_tmp
 
 cat >> "$pcr_sig" << EOF

--- a/builder/image.d/makesecureboot
+++ b/builder/image.d/makesecureboot
@@ -143,8 +143,8 @@ while read pcr_line; do
       trailing_comma=","
     fi
 
-		# Calculate the PCR policy digest
-		policy_init=$(printf '%0*d' 64 0)
+    # Calculate the PCR policy digest
+    policy_init=$(printf '%0*d' 64 0)
 
     command_code="0000017f"
     hash_alg_id="000B"

--- a/builder/image.d/makesecureboot
+++ b/builder/image.d/makesecureboot
@@ -149,7 +149,7 @@ while read pcr_line; do
 	policy_init=$(printf '%0*d' 64 0)
 
 	command_code="0000017f"
-	hash_alg_id="000B"
+	hash_alg_id="000b"
 	pcr_index="11"
 	
 	pcr_value_hash=$(echo -n "${PCR[1]}" | xxd -r -p | openssl dgst -sha256 -binary | xxd -p -c 256)

--- a/builder/image.d/makesecureboot
+++ b/builder/image.d/makesecureboot
@@ -105,9 +105,12 @@ case "$BUILDER_ARCH" in
 		;;
 esac
 
-# pre-calculation PCR11 values
+# pre-calculate PCR11 values
 unified_image_tmp="$(mktemp)"
 pcr_tmp="$(mktemp)"
+
+pcr_pub_key="/builder/cert/tpm2-pcr-public.pem"
+pcr_priv_key="/builder/cert/tpm2-pcr-private.pem"
 
 /usr/lib/systemd/ukify build \
 	--stub "$rootfs/usr/lib/systemd/boot/efi/linux$(tr '[:upper:]' '[:lower:]' <<< "$uefi_arch").efi.stub" \
@@ -116,15 +119,70 @@ pcr_tmp="$(mktemp)"
 	--cmdline "$cmdline" \
 	--output "$unified_image_tmp" \
 	--os-release "@$rootfs/etc/os-release" \
+	--pcrpkey "$pcr_pub_key" \
 	--pcr-banks "sha256" \
 	--measure > "$pcr_tmp"
 
-read -r pcr_value < "$pcr_tmp"
-pcr_value=$(echo $pcr_value | cut -d '=' -f2)
+# generate .pcrsig section
+pcr_sig="$(mktemp)"
 
-rm $unified_image_tmp
-rm $pcr_tmp
-# ***
+cat >> "$pcr_sig" << EOF
+{
+  "sha256" : [
+EOF
+
+pcr_counter=0
+while read pcr_line; do
+    # Split the string at the "="
+    IFS='=' read -ra PCR <<< $pcr_line
+    echo "${PCR[1]}"
+
+    if (( pcr_counter == 3 )); then
+      trailing_comma=""
+    else
+      trailing_comma=","
+    fi
+
+		# Calculate the PCR policy digest
+		policy_init=$(printf '%0*d' 64 0)
+
+    command_code="0000017f"
+    hash_alg_id="000B"
+
+    pcr_index="11"
+    pcr_value_hash=$(echo -n "${PCR[1]}" | xxd -r -p | openssl dgst -sha256 -binary | xxd -p -c 256)
+
+    pcr_select_bit_map=("00" "00" "00")
+    pcr_select_bit_map[$((pcr_index / 8))]=$(printf "%02x" $((1 << pcr_index % 8)))
+
+    pcr_selection=$(printf "00000001%s03%s%s%s" "$hash_alg_id" "${pcr_select_bit_map[0]}" "${pcr_select_bit_map[1]}" "${pcr_select_bit_map[2]}")
+    policy="${policy_init}$command_code$pcr_selection$pcr_value_hash"
+
+    policy_digest=$(echo -n "$policy" | xxd -r -p | openssl dgst -sha256 -binary | xxd -p -c 256)
+		# ***
+
+    cat >> "$pcr_sig" << EOF
+    {
+      "pcrs" : [
+        11
+      ],
+      "pkfp" : "$(openssl pkey -pubin -inform PEM -outform DER -in "$pcr_pub_key" | tail -c +25 | openssl dgst -sha256 -hex | awk '{print $2}')",
+      "pol" : "$policy_digest",
+      "sig" : "$(echo -n "$policy_digest" | xxd -r -p | openssl dgst -sha256 -sign "$pcr_priv_key" | openssl base64 -A)"
+    }$trailing_comma
+EOF
+
+	  pcr_counter=$((pcr_counter+1))
+
+    if (( pcr_counter == 4 )); then
+      break
+    fi
+done < $pcr_tmp
+
+cat >> "$pcr_sig" << EOF
+  ]
+}
+EOF
 
 # create unified image
 /usr/lib/systemd/ukify build \
@@ -133,7 +191,13 @@ rm $pcr_tmp
 	--initrd "$initrd" \
 	--cmdline "$cmdline" \
 	--output "$unified_image" \
-	--os-release "@$rootfs/etc/os-release"
+	--os-release "@$rootfs/etc/os-release" \
+	--pcrpkey "$pcr_pub_key" \
+	--section ".pcrsig:@$pcr_sig"
+
+rm $unified_image_tmp
+rm $pcr_tmp
+rm $pcr_sig
 
 efi_dir="$(mktemp -d)"
 mkdir -p "$efi_dir/EFI/BOOT/"

--- a/builder/image.d/makesecureboot
+++ b/builder/image.d/makesecureboot
@@ -148,7 +148,6 @@ while read pcr_line; do
 	# [2]: https://github.com/fishilico/shared/blob/master/python/crypto/tpm_ea_policy.py#L646
 	# [3]: https://trustedcomputinggroup.org/wp-content/uploads/TCG_TPM2_r1p59_Part3_Commands_pub.pdf#page=244
 	# [4]: https://trustedcomputinggroup.org/wp-content/uploads/TCG_TPM2_r1p59_Part1_Architecture_pub.pdf#page=113
-
 	policy_init=$(printf '%0*d' 64 0)
 
 	command_code="0000017f"

--- a/pkg.list
+++ b/pkg.list
@@ -31,4 +31,5 @@ systemd
 systemd-ukify
 uidmap
 xorriso
+xxd
 xz-utils


### PR DESCRIPTION
This PR changes the current encryption behaviour in favour of binding to signatures of PCR 11 values with signed public key based policies. Binding to PCR 7 is kept static, as the Secure Boot state should not change during e.g. a kernel upgrade.

Following steps are being performed during the build process if a partition with the feature flag `tpm2` is defined in the `fstab.mod` file:

1. PCR 11 values get pre-calculated during the build process using `ukfiy`(could be changed in the future to `systemd-measure`)
2. Generates a valid PCR signature JSON for the given build based on the values calculated in Step 1
3. Combines `.pcrsig` and `.pcrpkey` sections into the final bootable Unified Kernel Image
4. _Optional:_ This UKI file can also be signed if Secure Boot is enabled

These steps are executed by the OS during boot:

1.  When creating the defined partitions, `systemd-repart` binds the encryption to the signature values defined in `tpm2-pcr-signature.json` (`.pcrsig`)
2. `systemd-cryptsetup` then valides this signatures with the PCR 11 values present on the system and the public key provided using the `tpm2-pcr-public-key.pem` (`.pcrpkey`) certificate file
3. If all checks out, the boot process is continued and the partition can then be mounted and accessed