### PR TITLE
feat: seccomp_fake_xattr

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,5 +28,9 @@ RUN mv /aws_kms_pkcs11.so "/usr/lib/$(uname -m)-linux-gnu/pkcs11/aws_kms_pkcs11.
 COPY builder /builder
 RUN mkdir /builder/cert
 COPY setup_namespace /usr/sbin/setup_namespace
+RUN curl -sSLf https://github.com/gardenlinux/seccomp_fake_xattr/releases/download/latest/seccomp_fake_xattr-$(uname -m).tar.gz \
+	| gzip -d \
+	| tar -xO seccomp_fake_xattr-$(uname -m)/fake_xattr > /usr/bin/fake_xattr \
+	&& chmod +x /usr/bin/fake_xattr
 RUN echo 'root:1:65535' | tee /etc/subuid /etc/subgid > /dev/null
 ENTRYPOINT [ "/usr/sbin/setup_namespace" ]

--- a/setup_namespace
+++ b/setup_namespace
@@ -7,5 +7,5 @@ if [ "${1-}" = --second-stage ]; then
 	mount -t tmpfs -o size=4G tmpfs /tmp
 	"$@"
 else
-	unshare --map-root-user --map-users auto --map-groups auto --mount "$0" --second-stage "$@"
+	unshare --map-root-user --map-users auto --map-groups auto --mount fake_xattr "$0" --second-stage "$@"
 fi


### PR DESCRIPTION
use https://github.com/gardenlinux/seccomp_fake_xattr to enable selinux bulids on selinux hosts
