### PR TITLE
move fake_xattr to build time only

### DIFF
--- a/build
+++ b/build
@@ -130,4 +130,4 @@ if [ -d cert ]; then
 	container_mount_opts+=(-v "$PWD/cert:/builder/cert:ro")
 fi
 
-"$container_engine" run --rm "${container_run_opts[@]}" "${container_mount_opts[@]}" "$container_image" ${container_cmd[@]+"${container_cmd[@]}"} make --no-print-directory -C /builder "${make_opts[@]}" "$@" >&3
+"$container_engine" run --rm "${container_run_opts[@]}" "${container_mount_opts[@]}" "$container_image" ${container_cmd[@]+"${container_cmd[@]}"} fake_xattr make --no-print-directory -C /builder "${make_opts[@]}" "$@" >&3

--- a/setup_namespace
+++ b/setup_namespace
@@ -7,5 +7,5 @@ if [ "${1-}" = --second-stage ]; then
 	mount -t tmpfs -o size=4G tmpfs /tmp
 	"$@"
 else
-	unshare --map-root-user --map-users auto --map-groups auto --mount fake_xattr "$0" --second-stage "$@"
+	unshare --map-root-user --map-users auto --map-groups auto --mount "$0" --second-stage "$@"
 fi


### PR DESCRIPTION
having it in container entrypoint breaks tests, as test leaves orphaned processes running => causing test to never terminate 

(TODO: fix tests, to not leave processes running once completed)