### PR TITLE
Fix tags for release image by using manifest push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
           podman manifest create ghcr.io/${{ github.repository }}:${{ steps.bump.outputs.newVersion }}
           podman manifest add ghcr.io/${{ github.repository }}:${{ steps.bump.outputs.newVersion }} ghcr.io/${{ github.repository }}:amd64-"$SHA"
           podman manifest add ghcr.io/${{ github.repository }}:${{ steps.bump.outputs.newVersion }} ghcr.io/${{ github.repository }}:arm64-"$SHA"
-          podman push ghcr.io/${{ github.repository }}:${{ steps.bump.outputs.newVersion }}
+          podman manifest push ghcr.io/${{ github.repository }}:${{ steps.bump.outputs.newVersion }} docker://ghcr.io/${{ github.repository }}:${{ steps.bump.outputs.newVersion }}
           sed -i 's|container_image=localhost/builder|container_image=ghcr.io/${{ github.repository }}:${{ steps.bump.outputs.newVersion }}|' build
       - name: git tag
         run: |


### PR DESCRIPTION
The image of version 0.3 does not properly contain the multi-arch image as expected. It looks like 'manifest push' is the command we should use rather than 'image push'.

Note: As of today, github actions has podman v 3.x

The cli has changed in those versions, see:

- docs for v3 https://docs.podman.io/en/v3.0/markdown/podman-manifest-push.1.html
- docs for current https://docs.podman.io/en/stable/markdown/podman-manifest-push.1.html