### PR TITLE
Use skopeo to tag release image

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
           SHA=$(git rev-parse HEAD)
           skopeo login -u token -p ${{ github.token }} ghcr.io
           # Run skopeo in a container to get the latest version
-          podman run -v ${XDG_RUNTIME_DIR}/containers/auth.json:/auth.json docker://quay.io/skopeo/stable:latest copy --multi-arch all docker://ghcr.io/${{ github.repository }}:"$SHA" ghcr.io/${{ github.repository }}:${{ steps.bump.outputs.newVersion }}
+          podman run -v ${XDG_RUNTIME_DIR}/containers/auth.json:/auth.json docker://quay.io/skopeo/stable:latest copy --multi-arch all docker://ghcr.io/${{ github.repository }}:"$SHA" docker://ghcr.io/${{ github.repository }}:${{ steps.bump.outputs.newVersion }}
           sed -i 's|container_image=localhost/builder|container_image=ghcr.io/${{ github.repository }}:${{ steps.bump.outputs.newVersion }}|' build
       - name: git tag
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,13 +25,9 @@ jobs:
       - name: tag container image
         run: |
           SHA=$(git rev-parse HEAD)
-          podman login -u token -p ${{ github.token }} ghcr.io
-          podman pull ghcr.io/${{ github.repository }}:amd64-"$SHA"
-          podman pull ghcr.io/${{ github.repository }}:arm64-"$SHA"
-          podman manifest create ghcr.io/${{ github.repository }}:${{ steps.bump.outputs.newVersion }}
-          podman manifest add ghcr.io/${{ github.repository }}:${{ steps.bump.outputs.newVersion }} ghcr.io/${{ github.repository }}:amd64-"$SHA"
-          podman manifest add ghcr.io/${{ github.repository }}:${{ steps.bump.outputs.newVersion }} ghcr.io/${{ github.repository }}:arm64-"$SHA"
-          podman manifest push ghcr.io/${{ github.repository }}:${{ steps.bump.outputs.newVersion }} docker://ghcr.io/${{ github.repository }}:${{ steps.bump.outputs.newVersion }}
+          skopeo login -u token -p ${{ github.token }} ghcr.io
+          # Run skopeo in a container to get the latest version
+          podman run -v ${XDG_RUNTIME_DIR}/containers/auth.json:/auth.json docker://quay.io/skopeo/stable:latest copy --multi-arch all docker://ghcr.io/${{ github.repository }}:"$SHA" ghcr.io/${{ github.repository }}:${{ steps.bump.outputs.newVersion }}
           sed -i 's|container_image=localhost/builder|container_image=ghcr.io/${{ github.repository }}:${{ steps.bump.outputs.newVersion }}|' build
       - name: git tag
         run: |


### PR DESCRIPTION
Follow up for #75 as discussed, using skopeo.

Running skopeo in a container to ensure we get a recent version, not the old one on the github runner.