### PR TITLE
use mmdebstrap instead of debootstrap

### DIFF
--- a/builder/bootstrap
+++ b/builder/bootstrap
@@ -11,7 +11,7 @@ output="$5"
 chroot_dir="$(mktemp -d)"
 mount -t tmpfs -o size="$TEMPFS_SIZE" tmpfs "$chroot_dir"
 chmod 755 "$chroot_dir"
-container=lxc debootstrap --keyring "$keyring" --arch "$arch" --variant minbase "$version" "$chroot_dir" "$repo" trixie || (cat "$chroot_dir/debootstrap/debootstrap.log"; false)
+mmdebstrap --mode unshare --keyring "$keyring" --arch "$arch" --variant required --include ca-certificates --skip cleanup/apt/lists "$version" "$chroot_dir" "$repo"
 
 gpg --keyring "$keyring" --no-default-keyring --export -a > "$chroot_dir/etc/apt/trusted.gpg.d/keyring.asc"
 echo "deb $repo $version main" > "$chroot_dir/etc/apt/sources.list"

--- a/pkg.list
+++ b/pkg.list
@@ -7,7 +7,6 @@ cpio
 cryptsetup
 curl
 datefudge
-debootstrap
 dosfstools
 e2fsprogs
 fdisk
@@ -16,6 +15,7 @@ libcurl4
 libengine-pkcs11-openssl
 libjson-c5
 make
+mmdebstrap
 mtools
 ostree
 ostree-boot


### PR DESCRIPTION
currently building debian testing based images with debootstrap is broken due to the `t64` transition and debootstrap not handling `Provides: ` fields in the package index.

=> Let's switch to mmdebstrap which uses apt under the hood, thus handling `Provides: ` fields correctly