### PR TITLE
only publish to ghcr.io if pipeline runs on main branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,14 +11,17 @@ jobs:
           metric_frequency: 1
           comment_on_pr: false
       - uses: actions/checkout@v4
-      - name: build
+      - name: build builder container images
         run: |
           sudo apt-get update
           sudo env DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends qemu-user-static
-          podman login -u token -p ${{ github.token }} ghcr.io
           podman build --squash-all --arch amd64 --tag ghcr.io/${{ github.repository }}:amd64-${{ github.sha }} .
-          podman push ghcr.io/${{ github.repository }}:amd64-${{ github.sha }}
           podman build --squash-all --arch arm64 --tag ghcr.io/${{ github.repository }}:arm64-${{ github.sha }} .
+      - name: publish builder container images
+        if: github.ref == 'refs/heads/main'
+        run: |
+          podman login -u token -p ${{ github.token }} ghcr.io
+          podman push ghcr.io/${{ github.repository }}:amd64-${{ github.sha }}
           podman push ghcr.io/${{ github.repository }}:arm64-${{ github.sha }}
           podman manifest create ghcr.io/${{ github.repository }}:${{ github.sha }}
           podman manifest add ghcr.io/${{ github.repository }}:${{ github.sha }} ghcr.io/${{ github.repository }}:amd64-${{ github.sha }}


### PR DESCRIPTION
* main branch has branch protection, so only maintainers must be allowed to trigger publish process (which is enforced already)
* PR pipelines need to check if build works, so we must skip publishing in order to get green pipelines


