### PR TITLE
fix: make cross-arch build work with rosetta on mac

### DIFF
--- a/builder/image.manifest
+++ b/builder/image.manifest
@@ -6,8 +6,12 @@ chroot_dir="$(mktemp -d)"
 mount -t tmpfs tmpfs "$chroot_dir"
 tar --extract --xattrs --xattrs-include '*' --directory "$chroot_dir" < "$1"
 
+mount --rbind --make-rslave /proc "$chroot_dir/proc"
+
 #shellcheck disable=SC2016
 chroot "$chroot_dir" dpkg-query --show --showformat='${binary:Package} ${Version}\n' > "$2"
+
+umount -l "$chroot_dir/proc"
 
 umount "$chroot_dir"
 rmdir "$chroot_dir"


### PR DESCRIPTION
new podman machine now uses rosetta to emulate x86 on arm macos, rosetta, however, always requires /proc/ to be mounted in any chroot
