### PR TITLE
Relax constraints for partition label

### DIFF
--- a/builder/image.d/makepart
+++ b/builder/image.d/makepart
@@ -64,7 +64,7 @@ sed 's/#.*//;/^[[:space:]]*$/d' \
 
 	# check if fstab entry specifies source by UUID or LABEL
 	uuid="$(grep -oP '(?<=^UUID=)[a-fA-F0-9\-]*$' <<< "$source" || true)"
-	label="$(grep -oP '(?<=^LABEL=)[a-zA-Z0-9\_\-]*$' <<< "$source" || true)"
+	label="$(grep -oP '(?<=^LABEL=)[[:graph:]]*$' <<< "$source" || true)"
 
 	if [[ "$depth" = 0 ]]; then
 		# we iterate depth sorted, so all other partitions should already have been processed and written to fstab


### PR DESCRIPTION
**What this PR does / why we need it**:
The UEFI standard allows all human readable characters, and systemd-sysupdate encodes there a version string.

So relax the constraint to 'printing characters, excluding space', as a compromise.

**Which issue(s) this PR fixes**:
Fixes #98

**Special notes for your reviewer**:

**Release note**:
```bugfix| user

Relax constraints on labels for partitions.
```
