### PR TITLE
This commit supports `$LOG_WITH_TIMESTAMP` to generate shorter log output

### DIFF
--- a/build
+++ b/build
@@ -101,6 +101,7 @@ make_opts=(
 	COMMIT="$commit"
 	TIMESTAMP="$timestamp"
 	DEFAULT_VERSION="$default_version"
+	LOG_WITH_TIMESTAMP="${LOG_WITH_TIMESTAMP:-true}"
 )
 
 if [ "$use_kms" = 1 ]; then

--- a/builder/make_log
+++ b/builder/make_log
@@ -2,6 +2,7 @@
 
 set -eufo pipefail
 
+LOG_WITH_TIMESTAMP="${LOG_WITH_TIMESTAMP:-true}"
 target="$1"
 shift
 
@@ -9,6 +10,12 @@ echo -n | cat "${@/%/.log}" > "$target.log"
 
 while IFS= read -r line; do
 	date="$(date -u '+%Y-%m-%d %H:%M:%S')"
-	printf '[%s %s] %s\n' "$target" "$date" "$line"
+
+	if [ "${LOG_WITH_TIMESTAMP}" == "true" ]; then
+		printf '[%s %s] %s\n' "$target" "$date" "$line"
+	else
+		printf '[%s] %s\n' "$target" "$line"
+	fi
+
 	printf '[%s] %s\n' "$date" "$line" >> "$target.log"
 done


### PR DESCRIPTION
**What this PR does / why we need it**:
To support short log console messages if executed in CI environments `$CI` is considered nd if set to `true` removes date&time information.

**Which issue(s) this PR fixes**:
Fixes #36