### PR TITLE
fix: run mmdebstrap without apt sandbox user

### DIFF
--- a/builder/bootstrap
+++ b/builder/bootstrap
@@ -11,7 +11,7 @@ output="$5"
 chroot_dir="$(mktemp -d)"
 mount -t tmpfs -o size="$TEMPFS_SIZE" tmpfs "$chroot_dir"
 chmod 755 "$chroot_dir"
-mmdebstrap --mode unshare --keyring "$keyring" --arch "$arch" --variant required --include ca-certificates --skip check/qemu --skip cleanup/apt/lists "$version" "$chroot_dir" "$repo"
+mmdebstrap --mode unshare --keyring "$keyring" --arch "$arch" --variant required --include ca-certificates  --aptopt='APT::Sandbox::User "root"' --skip check/qemu --skip cleanup/apt/lists "$version" "$chroot_dir" "$repo"
 
 gpg --keyring "$keyring" --no-default-keyring --export -a > "$chroot_dir/etc/apt/trusted.gpg.d/keyring.asc"
 echo "deb $repo $version main" > "$chroot_dir/etc/apt/sources.list"


### PR DESCRIPTION
If the config repo is cloned with umask such that the keyring.gpg file is not world readable, then trying to read it with the _apt user fails.
Therefore, let's disable apt sandboxing in mmdebstrap as everything is containerized anyways.

fixes #102 