### PR TITLE
add arch specific and parallel build

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,0 +1,25 @@
+inputs:
+  arch:
+    description: 'Runner Architecture'
+    required: false
+    default: "amd64"
+runs:
+  using: composite
+  steps:
+    - name: install required packages
+      shell: bash
+      run: |
+        sudo rm -rf /{usr/{local/{lib/{android,heroku},.ghcup,share/{dotnet,powershell,miniconda,swift}},share/{dotnet,miniconda,swift}},opt/{hostedtoolcache,microsoft},imagegeneration}
+        sudo apt-get update
+        if [ "${{ inputs.arch }}" = "amd64" ]; then
+          sudo docker system prune -a -f
+          sudo env DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends qemu-user-static
+        elif [ "${{ inputs.arch }}" = "arm64" ]; then
+          sudo env DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends podman uidmap slirp4netns dbus-user-session
+          id="$(id -u)"
+          sudo systemctl start user@$id
+          export DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/$id/bus
+          systemctl --user start dbus
+          mkdir -p "$HOME/.config/containers"
+          echo 'unqualified-search-registries = ["docker.io"]' > "$HOME/.config/containers/registries.conf"
+        fi

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,25 +4,47 @@ on:
   workflow_dispatch:
 jobs:
   build:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [ amd64, arm64 ]
+    runs-on: ${{ matrix.arch == 'arm64' && 'ubuntu-latest-arm' || 'ubuntu-latest' }}
+    defaults:
+      run:
+        shell: bash
     steps:
       - uses: gardenlinux/workflow-telemetry-action@v2
         with:
           metric_frequency: 1
           comment_on_pr: false
       - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup
+        with:
+          arch: ${{ matrix.arch }}
       - name: build builder container images
         run: |
-          sudo apt-get update
-          sudo env DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends qemu-user-static
-          podman build --squash-all --arch amd64 --tag ghcr.io/${{ github.repository }}:amd64-${{ github.sha }} .
-          podman build --squash-all --arch arm64 --tag ghcr.io/${{ github.repository }}:arm64-${{ github.sha }} .
+          podman build --squash-all --arch ${{ matrix.arch }} --tag ghcr.io/${{ github.repository }}:${{ matrix.arch }}-${{ github.sha }} .
+      - name: publish arch specific builder container image
+        if: github.ref == 'refs/heads/main'
+        run: |
+          podman login -u token -p ${{ github.token }} ghcr.io
+          podman push ghcr.io/${{ github.repository }}:${{ matrix.arch }}-${{ github.sha }}
+  push:
+    runs-on: ubuntu-latest
+    needs: build
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: gardenlinux/workflow-telemetry-action@v2
+        with:
+          metric_frequency: 1
+          comment_on_pr: false
+      - uses: actions/checkout@v4
       - name: publish builder container images
         if: github.ref == 'refs/heads/main'
         run: |
           podman login -u token -p ${{ github.token }} ghcr.io
-          podman push ghcr.io/${{ github.repository }}:amd64-${{ github.sha }}
-          podman push ghcr.io/${{ github.repository }}:arm64-${{ github.sha }}
           podman manifest create ghcr.io/${{ github.repository }}:${{ github.sha }}
           podman manifest add ghcr.io/${{ github.repository }}:${{ github.sha }} ghcr.io/${{ github.repository }}:amd64-${{ github.sha }}
           podman manifest add ghcr.io/${{ github.repository }}:${{ github.sha }} ghcr.io/${{ github.repository }}:arm64-${{ github.sha }}
@@ -41,7 +63,7 @@ jobs:
   # Run for new commits on the main branch
   release-latest:
     runs-on: ubuntu-latest
-    needs: build
+    needs: push
     if: github.ref == 'refs/heads/main'
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
**What this PR does / why we need it**:

Add arch specific and parallel build. Uses arch specific runners and speeds up build process.
Uses the same container build mechanisms as https://github.com/gardenlinux/gardenlinux.