### PR TITLE
Fix docker compatibility

### DIFF
--- a/build
+++ b/build
@@ -124,4 +124,9 @@ if [ -d cert ]; then
 	container_mount_opts+=(-v "$PWD/cert:/builder/cert:ro")
 fi
 
+if [ "$container_engine" = "docker" ] && out=$(sysctl kernel.apparmor_restrict_unprivileged_userns) && [[ $out = "kernel.apparmor_restrict_unprivileged_userns = 1" ]]; then
+	echo Allow unprivileged user namespaces, use podman to avoid this setting
+	sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
+fi
+
 "$container_engine" run --rm "${container_run_opts[@]}" "${container_mount_opts[@]}" "$container_image" ${container_cmd[@]+"${container_cmd[@]}"} fake_xattr make --no-print-directory -C /builder "${make_opts[@]}" "$@" >&3

--- a/setup_namespace
+++ b/setup_namespace
@@ -6,6 +6,9 @@ if [ "${1-}" = --second-stage ]; then
 	shift
 	mount -t tmpfs -o size=4G tmpfs /tmp
 	"$@"
+	if [ -d /builder/.build ]; then
+		chown $(stat -c "%u:%g" /builder/.build) -R /builder/.build
+	fi
 else
 	unshare --map-root-user --map-users auto --map-groups auto --mount "$0" --second-stage "$@"
 fi


### PR DESCRIPTION
**What this PR does / why we need it**:
- automatically enable unprivileged user namespaces when using `docker` which have been [disabled by default for security reasons](https://ubuntu.com/blog/ubuntu-23-10-restricted-unprivileged-user-namespaces)
- fixes ownership issues described in #86, when building with `docker` and an empty `.build `directory the files were owned by root, preventing access for podman 

**Which issue(s) this PR fixes**:
Fixes #86