### PR TITLE
fix: apparmor build profile is disabled after reboot

### DIFF
--- a/build
+++ b/build
@@ -134,20 +134,17 @@ if [ "$container_engine" = "docker" ] \
 	&& [ ! "$apparmor_profile" ] \
 	&& out=$(sysctl kernel.apparmor_restrict_unprivileged_userns 2> /dev/null) \
 	&& [[ $out = "kernel.apparmor_restrict_unprivileged_userns = 1" ]]; then
-	if [ ! -d /etc/apparmor.d/containers ] || [ ! -f /etc/apparmor.d/containers/builder ]; then
+	if [ ! -f /etc/apparmor.d/builder ]; then
 		echo "You are using Docker on a system restricting unprivileged user namespaces with apparmor, which prevents a successful build. For more information please refer to the #Usage section in the README."
-		read -r -p "Do you want to permanently create a new apparmor profile at /etc/apparmor.d/containers/builder to solve the issue? [Y/n] " response
+		read -r -p "Do you want to permanently create a new apparmor profile at /etc/apparmor.d/builder to solve the issue? [Y/n] " response
 		response=${response,,}
 		if [[ "$response" =~ ^(yes|y)$ ]]; then
-			if [ ! -d /etc/apparmor.d/containers ]; then
-				sudo mkdir /etc/apparmor.d/containers
-			fi
-			if [ ! -f /etc/apparmor.d/containers/builder ]; then
+			if [ ! -f /etc/apparmor.d/builder ]; then
 				profile="abi <abi/4.0>, include <tunables/global> profile builder flags=(unconfined) {userns, }"
-				echo "$profile" | sudo tee /etc/apparmor.d/containers/builder > /dev/null
-				sudo apparmor_parser -r -W /etc/apparmor.d/containers/builder
+				echo "$profile" | sudo tee /etc/apparmor.d/builder > /dev/null
+				sudo apparmor_parser -r -W /etc/apparmor.d/builder
 			fi
-			echo "Created profile builder at /etc/apparmor.d/containers/builder"
+			echo "Created profile builder at /etc/apparmor.d/builder"
 		else
 			echo Abort.
 			exit 1


### PR DESCRIPTION
After using the apparmor builder profile from `/etc/apparmor.d/containers/builder` for a build using docker as the container engine, the build didn't work anymore after rebooting the machine.
It failed because the builder profile was not enabled anymore, as apparmor only automatically enables profiles directly located at `/etc/apparmor.d/`.

This PR fixes this issue by changing the builder profile path from `/etc/apparmor.d/containers/builder` to `/etc/apparmor.d/builder` 