### PR TITLE
feat: output target requirements

### DIFF
--- a/builder/Makefile
+++ b/builder/Makefile
@@ -89,5 +89,5 @@ $(foreach artifact_rule,$(shell ./make_get_artifact_rules),$(eval $(call artifac
 	ln -f -s -r '$<' '.build/$*'
 
 # prevents match anything rule from applying to Makefile and image/convert scripts
-Makefile image image.release image.manifest $(shell find features -name 'convert.*' -o -name image -o -name 'image.*'):
+Makefile image image.release image.manifest image.requirements $(shell find features -name 'convert.*' -o -name image -o -name 'image.*'):
 	true

--- a/builder/image.requirements
+++ b/builder/image.requirements
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -eufo pipefail
+
+uefi=false
+secureboot=false
+tpm2=false
+
+IFS=',' read -r -a features <<< "$BUILDER_FEATURES"
+for feature in "${features[@]}"; do
+	if [ -e "/builder/features/$feature/requirements.mod" ]; then
+		source "/builder/features/$feature/requirements.mod"
+	fi
+done
+
+cat > "$2" << EOF
+arch=$BUILDER_ARCH
+uefi=$uefi
+secureboot=$secureboot
+tpm2=$tpm2
+EOF

--- a/builder/make_get_artifact_rules
+++ b/builder/make_get_artifact_rules
@@ -3,7 +3,7 @@
 set -euo pipefail
 shopt -s nullglob
 
-extensions=(release manifest raw)
+extensions=(release manifest requirements raw)
 
 for feature in "features/"*; do
 	for i in "$feature/"{image,convert}.*; do

--- a/builder/make_list_build_artifacts
+++ b/builder/make_list_build_artifacts
@@ -7,7 +7,7 @@ cname="$1"
 
 IFS=',' read -r -a features < <(./parse_features --feature-dir features --cname "$cname" features)
 
-artifacts=(".build/$cname-$COMMIT.tar" ".build/$cname-$COMMIT.release" ".build/$cname-$COMMIT.manifest")
+artifacts=(".build/$cname-$COMMIT.tar" ".build/$cname-$COMMIT.release" ".build/$cname-$COMMIT.manifest" ".build/$cname-$COMMIT.requirements")
 
 for feature in "${features[@]}"; do
 	for i in "features/$feature/"{image,convert}.*; do
@@ -18,7 +18,7 @@ for feature in "${features[@]}"; do
 	done
 done
 
-if [ "${#artifacts[@]}" = 3 ] && [ -n "$(./parse_features --feature-dir "features" --cname "$cname" platforms)" ]; then
+if [ "${#artifacts[@]}" = 4 ] && [ -n "$(./parse_features --feature-dir "features" --cname "$cname" platforms)" ]; then
 	artifacts+=(".build/$cname-$COMMIT.raw")
 fi
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Output an additional build artifact `${target_cname}.requirements` specifying what runtime requirements a given build target has. This will allow tools such as GLCI or platform tests to better determine what features need to be enabled on published images or for VM creation, rather then relying on hardcoded mappings between features and requirements.

(See PRs and issues mentioned below for how this would be utilised)