### PR TITLE
always add raw image file to artifacts for tests in QEMU VM

### DIFF
--- a/builder/make_list_build_artifacts
+++ b/builder/make_list_build_artifacts
@@ -18,7 +18,8 @@ for feature in "${features[@]}"; do
 	done
 done
 
-if [ "${#artifacts[@]}" = 4 ] && [ -n "$(./parse_features --feature-dir "features" --cname "$cname" platforms)" ]; then
+# always add raw image file to artifacts for tests in QEMU VM
+if [ -n "$(./parse_features --feature-dir "features" --cname "$cname" platforms)" ]; then
 	artifacts+=(".build/$cname-$COMMIT.raw")
 fi
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This adds the `*.raw` image file that is always created anyways to the artifacts that are uploaded to S3.
We want to test those `.raw` files in QEMU VMs. The qemu test is currently skipped with error message:

```
no raw file, skipping QEMU test
```
https://github.com/gardenlinux/gardenlinux/actions/runs/17147445588/job/48648191622

