### PR TITLE
feat: mount all features

### DIFF
--- a/build
+++ b/build
@@ -81,11 +81,8 @@ container_mount_opts=(
 	-v "$(realpath "$target_dir"):/builder/.build"
 )
 
-for feature in features/*; do
-	if [ -d "$feature" ]; then
-		container_mount_opts+=(-v "$(realpath -- "$feature"):/builder/$feature:ro")
-	fi
-done
+# mount all features to enable dynamic discovery of requirements.mod files
+container_mount_opts+=(-v "$(realpath -- "features"):/builder/features:ro")
 
 if [ "$container_image" = localhost/builder ]; then
 	dir="$(dirname -- "$(realpath -- "${BASH_SOURCE[0]}")")"


### PR DESCRIPTION
**What this PR does / why we need it**:

feat: mount all features

This enables dynamic discovery of requirements.mod files

This is a follow-up of https://github.com/gardenlinux/builder/pull/148
