### PR TITLE
docs: remove "AI-generated phrasing"

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ https://lists.neonephos.org/g/gardenlinux-security-embargo
 ## Licensing
 
 Copyright 2025 SAP SE or an SAP affiliate company and GardenLinux contributors.
-Please see our [LICENSE](LICENSE.md) for copyright and license information.
+See our [LICENSE](LICENSE.md) for copyright and license information.
 Detailed information including third-party components and their
 licensing/copyright information is available
 [via the REUSE tool](https://reuse.software).

--- a/docs/how-to/custom-feature.md
+++ b/docs/how-to/custom-feature.md
@@ -231,8 +231,6 @@ index 181a646..9e4261e 100644
 
 Commit and push your changes and GitHub will build the image for you.
 
-You have successfully created your first feature with the Builder and set up a CI pipeline to build the image.
-
 ## Related Topics
 
 <RelatedTopics />

--- a/docs/overview/README.md
+++ b/docs/overview/README.md
@@ -19,13 +19,13 @@ github_target_path: "docs/reference/supporting_tools/builder.md"
 
 ## Overview
 
-The Builder is a powerful tool for effortlessly building Linux system images based on config directories. It serves as the primary build tooling for the [gardenlinux](https://github.com/gardenlinux/gardenlinux) project.
+The Builder builds Linux system images based on config directories. It serves as the primary build tooling for the [gardenlinux](https://github.com/gardenlinux/gardenlinux) project.
 
 By default, the Builder runs inside rootless Podman, enabling building without requiring elevated permissions.
 
 ## Requirements
 
-The Builder has minimal dependencies and only requires a working container engine. We recommend using rootless Podman. Please refer to the [Podman rootless setup guide](https://github.com/containers/podman/blob/main/docs/tutorials/rootless_tutorial.md) for instructions on setting it up.
+The Builder has minimal dependencies and only requires a working container engine. We recommend using rootless Podman. Refer to the [Podman rootless setup guide](https://github.com/containers/podman/blob/main/docs/tutorials/rootless_tutorial.md) for instructions on setting it up.
 
 ## Usage
 
@@ -67,7 +67,7 @@ For a quick start guide on setting up your own config directory with your own fe
 
 ### Example Config Directory
 
-If you're new to configuring the Builder, you can find a minimal example config directory at [gardenlinux/builder_example](https://github.com/gardenlinux/builder_example). For a more comprehensive example, refer to the main [gardenlinux](https://github.com/gardenlinux/gardenlinux) repository.
+If you're new to configuring the Builder, you can find a minimal example config directory at [gardenlinux/builder_example](https://github.com/gardenlinux/builder_example). For a more complete example, refer to the main [gardenlinux](https://github.com/gardenlinux/gardenlinux) repository.
 
 Feel free to explore these examples to gain a better understanding of how to effectively structure your own config directory.
 

--- a/docs/overview/README.md
+++ b/docs/overview/README.md
@@ -19,7 +19,7 @@ github_target_path: "docs/reference/supporting_tools/builder.md"
 
 ## Overview
 
-The Builder builds Linux system images based on config directories. It serves as the primary build tooling for the [gardenlinux](https://github.com/gardenlinux/gardenlinux) project.
+The Builder builds Linux system images based on config directories. It is the primary build tooling for the [gardenlinux](https://github.com/gardenlinux/gardenlinux) project.
 
 By default, the Builder runs inside rootless Podman, enabling building without requiring elevated permissions.
 
@@ -69,7 +69,7 @@ For a quick start guide on setting up your own config directory with your own fe
 
 If you're new to configuring the Builder, you can find a minimal example config directory at [gardenlinux/builder_example](https://github.com/gardenlinux/builder_example). For a more complete example, refer to the main [gardenlinux](https://github.com/gardenlinux/gardenlinux) repository.
 
-Feel free to explore these examples to gain a better understanding of how to effectively structure your own config directory.
+These examples demonstrate how to structure a config directory.
 
 ## Local Development
 

--- a/docs/reference/features.md
+++ b/docs/reference/features.md
@@ -109,7 +109,7 @@ The format is:
   - `final_partition`: ensure this partition is placed at the end of the partition table regardless of default sorting. if you don't know why you'd need this you likely shouldn't use it!
 
 The `fstab` can be defined with an equally named file in one and only one feature.
-Additionally, other features can apply modifications to this base `fstab`.
+Other features can apply modifications to this base `fstab`.
 For this features can define executable `fstab.mod` scripts.
 These scripts are executed in the same order as regular config scripts, each receiving the output of the previous script as its input.
 The first script in the series receives the init `fstab` file.
@@ -121,7 +121,7 @@ The output of the final file will be used as the effective `fstab`.
 
 ## `image`, `image.<ext>`, `convert.<ext>`, `convert.<extA>~<extB>`
 
-Alternative, or additionally, to the `fstab` mechanism the builder also offers more fine grained control over image creation via explicit image create and convert scripts.
+As an alternative to the `fstab` mechanism, the builder also offers more fine grained control over image creation via explicit image create and convert scripts.
 
 The `image` and `image.<ext>` scripts are used to directly create an image given a rootfs tar.
 They get a path to the rootfs tar as `argv[1]` and a path where the target image should be written as `argv[2]`.


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR removes "AI-generated phrasing". Definitions what qualifies at such phrasing [as documented](https://github.com/gardenlinux/docs-ng/blob/dda94b0dd8911e5688dbc81f73b42803ccd1944a/docs/contributing/documentation/writing_good_docs.md#ai-generated-phrasing-to-avoid).
The removal of the phrases was done via the [documentation-humanize workflow](https://github.com/gardenlinux/agent-skills/blob/b4681613ef763884f4e80d4ffb29649d160121a5/workflows/documentation-humanize.md) and [skill](https://github.com/gardenlinux/agent-skills/blob/b4681613ef763884f4e80d4ffb29649d160121a5/skills/documentation-humanize/SKILL.md).