### PR TITLE
chore: rename docs-ng to docs and fix netlify links

### DIFF
--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -2,12 +2,12 @@ name: Documentation Quality Check
 
 on:
   pull_request:
-    branches: [main, docs-ng]
+    branches: [main]
     types: [opened, synchronize, reopened, closed]
     paths:
       - 'docs/**'
   push:
-    branches: [main, docs-ng]
+    branches: [main]
     paths:
       - 'docs/**'
 
@@ -15,14 +15,14 @@ jobs:
   docs-checks:
     # Skip checks on closed PRs (only need the notification)
     if: github.event_name != 'pull_request' || github.event.action != 'closed'
-    uses: gardenlinux/docs-ng/.github/workflows/docs-checks.yml@main
+    uses: gardenlinux/docs/.github/workflows/docs-checks.yml@main
     with:
       override-repo: ${{ github.event.repository.name }}
       override-ref: ${{ github.head_ref || github.ref_name }}
       override-commit: ${{ github.event.pull_request.head.sha || github.sha }}
 
-  notify-docs-ng:
-    name: Notify docs-ng
+  notify-docs:
+    name: Notify docs
     needs: [docs-checks]
     runs-on: ubuntu-24.04
     # Only notify for PR events (not push events which lack PR context)
@@ -41,9 +41,9 @@ jobs:
         with:
           app-id: ${{ secrets.DOCS_BOT_APP_ID }}
           private-key: ${{ secrets.DOCS_BOT_PRIVATE_KEY }}
-          repositories: docs-ng
+          repositories: docs
 
-      - name: Send repository dispatch to docs-ng
+      - name: Send repository dispatch to docs
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           github-token: ${{ steps.app-token.outputs.token }}
@@ -59,7 +59,7 @@ jobs:
 
             await github.rest.repos.createDispatchEvent({
               owner: 'gardenlinux',
-              repo: 'docs-ng',
+              repo: 'docs',
               event_type: 'docs-pr',
               client_payload: {
                 repo: '${{ github.event.repository.name }}',
@@ -71,4 +71,4 @@ jobs:
                 event: isMergedPR ? 'merged' : 'pr_success'
               }
             });
-            core.info('Repository dispatch sent to docs-ng');
+            core.info('Repository dispatch sent to docs');

--- a/README.md
+++ b/README.md
@@ -12,17 +12,27 @@ delegates all internal build steps to it. As a result, the only hard dependency
 on the host system is a working container engine — no specific Linux
 distribution, compiler toolchain, or package set is required on the build host.
 
+If you want to use a modified builder docker image, you can edit your changes into the `Dockerfile` and run the image build with
+```
+cd gardenlinux
+./build --container-image localhost/builder aws-gardener_prod
+```
+
+## SBOM Generation
+
+After image build time a Software Bill of Materials (SBOM) is created in CycloneDX JSON-format. To produce the SBOM a tool called `syft` is downloaded during build container time. To verify the integrity the offloaded checksums file is included in the builder's directory. To update to a newer syft-release update the container ARG in the `Dockerfile` and update the checksums-file for this release as well.
+
 ## Documentation
 
 For
-[explanations](https://gardenlinux-docs.netlify.app/explanation/builder.html) on
+[explanations](https://docs.gardenlinux.org/explanation/builder.html) on
 the structure of our build system,
-[references](https://gardenlinux-docs.netlify.app/reference/builder.html) of
+[references](https://docs.gardenlinux.org/reference/builder.html) of
 builder's CLI interface and detailed
-[how-to guides](https://gardenlinux-docs.netlify.app/how-to/building-images.html)
+[how-to guides](https://docs.gardenlinux.org/how-to/building-images.html)
 on how to build images for different
-[flavors](https://gardenlinux-docs.netlify.app/explanation/flavors.html), visit
-our [documentation](https://gardenlinux-docs.netlify.app/).
+[flavors](https://docs.gardenlinux.org/explanation/flavors.html), visit
+our [documentation](https://docs.gardenlinux.org/).
 
 # Community
 
@@ -39,17 +49,6 @@ https://lists.neonephos.org/g/gardenlinux-security
 For embargoed security related topics, this list is for you:
 
 https://lists.neonephos.org/g/gardenlinux-security-embargo
-
-
-If you want to use a modified builder docker image, you can edit your changes into the `Dockerfile` and run the image build with
-```
-cd gardenlinux
-./build --container-image localhost/builder aws-gardener_prod
-```
-
-## SBOM Generation
-
-After image build time a Software Bill of Materials (SBOM) is created in CycloneDX JSON-format. To produce the SBOM a tool called `syft` is downloaded during build container time. To verify the integrity the offloaded checksums file is included in the builder's directory. To update to a newer syft-release update the container ARG in the `Dockerfile` and update the checksums-file for this release as well.
 
 ## Licensing
 


### PR DESCRIPTION
**What this PR does / why we need it**:

chore: rename docs-ng to docs and fix netlify links
