### PR TITLE
feat: remove migration frontmatter as migration is done

### DIFF
--- a/docs/explanation/builder.md
+++ b/docs/explanation/builder.md
@@ -10,10 +10,6 @@ related_topics:
   - /how-to/secure-boot
   - /how-to/choosing-flavors
   - /how-to/getting-images
-migration_status: "done"
-migration_issue: "https://github.com/gardenlinux/gardenlinux/issues/4627"
-migration_stakeholder: "@tmang0ld, @yeoldegrove, @ByteOtter"
-migration_approved: false
 github_org: gardenlinux
 github_repo: builder
 github_source_path: docs/explanation/builder.md

--- a/docs/explanation/features.md
+++ b/docs/explanation/features.md
@@ -8,10 +8,6 @@ related_topics:
   - /reference/features/
   - /reference/adr/0034-feature-terminology.md
   - /reference/adr/0020-enforce-single-platform-by-default-in-builder.md
-migration_status: "done"
-migration_issue: "https://github.com/gardenlinux/gardenlinux/issues/4600"
-migration_stakeholder: "@tmangold, @yeoldegrove, @ByteOtter"
-migration_approved: false
 github_org: gardenlinux
 github_repo: builder
 github_source_path: docs/explanation/features.md

--- a/docs/how-to/building-images.md
+++ b/docs/how-to/building-images.md
@@ -10,10 +10,6 @@ related_topics:
   - /how-to/secure-boot
   - /how-to/choosing-flavors
   - /how-to/getting-images
-migration_status: "done"
-migration_issue: "https://github.com/gardenlinux/gardenlinux/issues/4627"
-migration_stakeholder: "@tmang0ld, @yeoldegrove, @ByteOtter"
-migration_approved: false
 github_org: gardenlinux
 github_repo: builder
 github_source_path: "docs/how-to/building-images.md"

--- a/docs/how-to/custom-feature.md
+++ b/docs/how-to/custom-feature.md
@@ -5,10 +5,6 @@ related_topics:
   - /reference/supporting_tools/builder.md
   - /reference/features/
   - /how-to/custom-feature
-migration_status: "done"
-migration_issue: "https://github.com/gardenlinux/gardenlinux/issues/4628"
-migration_stakeholder: "@tmangold, @yeoldegrove, @ByteOtter"
-migration_approved: false
 github_org: gardenlinux
 github_repo: builder
 github_source_path: docs/how-to/custom-feature.md

--- a/docs/overview/README.md
+++ b/docs/overview/README.md
@@ -5,10 +5,6 @@ related_topics:
   - /reference/supporting_tools/builder.md
   - /reference/features/
   - /how-to/custom-feature
-migration_status: "done"
-migration_issue: "https://github.com/gardenlinux/gardenlinux/issues/4627"
-migration_stakeholder: "@tmangold, @yeoldegrove, @ByteOtter"
-migration_approved: false
 github_org: gardenlinux
 github_repo: python-gardenlinux-lib
 github_source_path: docs/overview/index.md

--- a/docs/reference/builder.md
+++ b/docs/reference/builder.md
@@ -10,10 +10,6 @@ related_topics:
   - /how-to/secure-boot
   - /how-to/choosing-flavors
   - /how-to/getting-images
-migration_status: "done"
-migration_issue: "https://github.com/gardenlinux/gardenlinux/issues/4627"
-migration_stakeholder: "@tmang0ld, @yeoldegrove, @ByteOtter"
-migration_approved: false
 github_org: gardenlinux
 github_repo: builder
 github_source_path: docs/reference/builder.md

--- a/docs/reference/features.md
+++ b/docs/reference/features.md
@@ -5,10 +5,6 @@ related_topics:
   - /reference/supporting_tools/builder.md
   - /reference/features/
   - /how-to/custom-feature
-migration_status: "adapt"
-migration_issue: "https://github.com/gardenlinux/gardenlinux/issues/4600"
-migration_stakeholder: "@tmangold, @yeoldegrove, @ByteOtter"
-migration_approved: false
 github_org: gardenlinux
 github_repo: builder
 github_source_path: docs/reference/features.md


### PR DESCRIPTION
**What this PR does / why we need it**:

In https://github.com/gardenlinux/gardenlinux/issues/4332 we used migration markers in the frontmatter to track the migration status. These can now be removed as the documentation system is live.

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardenlinux/gardenlinux/issues/5048
