### PR TITLE
Docs: Fix copyright header in root LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2020-2026 SAP SE, an SAP affiliated company and the Garden Linux contributors.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
**What this PR does / why we need it**:

Fills out the placeholder copyright text in the root LICENSE file.

**Which issue(s) this PR fixes**:
Tracks https://github.com/gardenlinux/gardenlinux/issues/5107

